### PR TITLE
make secretbox methods return nullable

### DIFF
--- a/tweetnacl-multiplatform/src/commonMain/kotlin/net/avianlabs/solana/tweetnacl/TweetNaCl.kt
+++ b/tweetnacl-multiplatform/src/commonMain/kotlin/net/avianlabs/solana/tweetnacl/TweetNaCl.kt
@@ -16,6 +16,7 @@ public interface TweetNaCl {
      *
      * @param message: The message to sign
      * @param secretKey: The secret key to sign the message with
+     *
      * @return The signature of the message
      */
     public fun sign(message: ByteArray, secretKey: ByteArray): ByteArray
@@ -24,6 +25,7 @@ public interface TweetNaCl {
      * Returns a new signing key pair generated deterministically from a seed
      *
      * @param seed: 32 byte seed. Must contain enough entropy to be secure.
+     *
      * @return A new key pair generated from the seed
      */
     public fun generateKey(seed: ByteArray): Ed25519Keypair
@@ -32,6 +34,7 @@ public interface TweetNaCl {
      * Returns whether the given publicKey falls in the Ed25519 elliptic curve
      *
      * @param publicKey: The public key to check
+     *
      * @return Whether the public key is on the curve
      */
     public fun isOnCurve(publicKey: ByteArray): Boolean
@@ -65,18 +68,20 @@ public interface TweetNaCl {
      *
      * @param message: The message to encrypt
      * @param nonce: The nonce to use for encryption
-     * @return The encrypted message
+     *
+     * @return The encrypted message, or null if there was an error
      */
-    public fun box(message: ByteArray, nonce: ByteArray): ByteArray
+    public fun box(message: ByteArray, nonce: ByteArray): ByteArray?
 
     /**
      * Authenticates and decrypts the given secret box using the key and the nonce.
      *
      * @param box: The encrypted message
      * @param nonce: The nonce used for encryption
-     * @return The decrypted message
+     *
+     * @return The decrypted message, or null if there was an error
      */
-    public fun open(box: ByteArray, nonce: ByteArray): ByteArray
+    public fun open(box: ByteArray, nonce: ByteArray): ByteArray?
 
     public companion object {
       public const val NONCE_BYTES: Int = 24

--- a/tweetnacl-multiplatform/src/commonTest/kotlin/SecretBoxTest.kt
+++ b/tweetnacl-multiplatform/src/commonTest/kotlin/SecretBoxTest.kt
@@ -1,7 +1,6 @@
 package net.avianlabs.solana.tweetnacl
 
 import kotlin.test.Test
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalStdlibApi::class)
@@ -16,7 +15,7 @@ class SecretBoxTest {
 
     assertEquals(
       "6b6608e77e7c4024147baa01d7576a3a5a2852a6278bac8eca4db1e6",
-      result.toHexString(),
+      result!!.toHexString(),
     )
   }
 
@@ -27,10 +26,10 @@ class SecretBoxTest {
         "6b6608e77e7c4024147baa01d7576a3a5a2852a6278bac8eca4db1e6".hexToByteArray(),
         ByteArray(24)
       )
-    
+
     assertEquals(
       "Hello world!",
-      result.decodeToString(),
+      result!!.decodeToString(),
     )
   }
 }

--- a/tweetnacl-multiplatform/src/jvmMain/kotlin/net/avianlabs/solana/tweetnacl/TweetNaCl.kt
+++ b/tweetnacl-multiplatform/src/jvmMain/kotlin/net/avianlabs/solana/tweetnacl/TweetNaCl.kt
@@ -20,9 +20,9 @@ internal actual fun generateKeyInternal(seed: ByteArray): Ed25519Keypair {
 
 internal actual fun secretBoxInternal(secretKey: ByteArray): TweetNaCl.SecretBox =
   object : TweetNaCl.SecretBox {
-    override fun box(message: ByteArray, nonce: ByteArray): ByteArray =
+    override fun box(message: ByteArray, nonce: ByteArray): ByteArray? =
       TweetNaclFast.SecretBox(secretKey).box(message, nonce)
 
-    override fun open(box: ByteArray, nonce: ByteArray): ByteArray =
+    override fun open(box: ByteArray, nonce: ByteArray): ByteArray? =
       TweetNaclFast.SecretBox(secretKey).open(box, nonce)
   }


### PR DESCRIPTION
this matches the actual api contract of the underlying tweetnacl java implementation