### PR TITLE
Bump toolchain to latest stable + tidy build config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,10 @@
-version=0.4.5
+version=0.5.0
 # Kotlin
-#kotlin.code.style=official
 kotlin.incremental.multiplatform=true
-kotlin.mpp.stability.nowarn=true
 android.useAndroidX=true
 # Increase memory for in-process compiler execution.
 org.gradle.jvmargs=-Xmx3g
-# https://kotlinlang.org/docs/migrating-multiplatform-project-to-14.html#migrate-to-the-hierarchical-project-structure
+# Required so the TweetNaCl cinterop is exposed via the appleMain/nativeMain hierarchy.
 kotlin.mpp.enableCInteropCommonization=true
-kotlin.mpp.enableHierarchicalCommonization=true
-kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.ignoreDisabledTargets=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,31 +5,28 @@ androidMinSdk = "24"
 
 # Plugins
 androidCacheFix = "3.0.2"
-androidGradle = "9.0.1"
+androidGradle = "9.2.0"
 androidJunit5 = "2.0.1"
 detekt = "1.23.8"
 jacoco = "0.8.7"
-kotlin = "2.3.0"
+kotlin = "2.3.20"
 mavenPublish = "0.36.0"
-skie = "0.10.9"
+skie = "0.10.11"
 
 # Libraries
 arrow = "2.1.2"
 junit5 = "6.0.2"
 junitPioneer = "2.3.0"
 kermit = "2.0.6"
-khash = "1.1.3"
 kotlinxCoroutines = "1.10.2"
 kotlinLogging = "7.0.14"
 ktor = "3.2.0"
-okhttp = "5.3.2"
 okio = "3.16.4"
 serialization = "1.10.0"
 
 [libraries]
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 bouncyCastle = { module = "org.bouncycastle:bcpkix-jdk15to18", version = "1.84" }
-coreLibraryDesugaring = { module = "com.android.tools:desugar_jdk_libs", version = "2.1.5" }
 coroutinesAndroid = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 coroutinesJdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinxCoroutines" }
@@ -47,8 +44,6 @@ ktorClientWinHttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "kto
 ktorSerializationKotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktorUtils = { module = "io.ktor:ktor-utils", version.ref = "ktor" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-okhttpLoggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 serializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 skie-configurationAnnotations = { module = "co.touchlab.skie:configuration-annotations", version.ref = "skie" }
@@ -60,7 +55,6 @@ junit5Engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref 
 junit5Params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
 junit5api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
 junitPioneer = { module = "org.junit-pioneer:junit-pioneer", version.ref = "junitPioneer" }
-junitVintage = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
 kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,10 @@ pluginManagement {
   }
 }
 
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
 //  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
@@ -31,11 +35,3 @@ include(":solana-kotlin")
 include(":solana-kotlin-arrow-extensions")
 include(":tweetnacl-multiplatform")
 include(":codegen")
-
-dependencyResolutionManagement {
-  versionCatalogs {
-    create("libs") {
-      from(files("libs.versions.toml"))
-    }
-  }
-}

--- a/solana-kotlin-arrow-extensions/build.gradle.kts
+++ b/solana-kotlin-arrow-extensions/build.gradle.kts
@@ -13,12 +13,9 @@ version = properties["version"] as String
 kotlin {
   applyDefaultHierarchyTemplate()
   explicitApi()
+  jvmToolchain(17)
 
-  jvm {
-    compilerOptions {
-      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-    }
-  }
+  jvm()
 
   mingwX64()
   linuxX64()
@@ -48,12 +45,6 @@ kotlin {
     val linuxMain by getting
 
     val mingwMain by getting
-  }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-  compilerOptions {
-    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
   }
 }
 

--- a/solana-kotlin/build.gradle.kts
+++ b/solana-kotlin/build.gradle.kts
@@ -17,12 +17,9 @@ version = properties["version"] as String
 kotlin {
   applyDefaultHierarchyTemplate()
   explicitApi()
+  jvmToolchain(17)
 
-  jvm {
-    compilerOptions {
-      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-    }
-  }
+  jvm()
 
   listOf(
     iosArm64(),
@@ -120,12 +117,6 @@ multiplatformSwiftPackage {
   packageName("SolanaKotlin")
   zipFileName("SolanaKotlin")
   distributionMode { remote("https://github.com/avianlabs/solana-kotlin/releases/download/$version") }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-  compilerOptions {
-    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-  }
 }
 
 signing {

--- a/tweetnacl-multiplatform/build.gradle.kts
+++ b/tweetnacl-multiplatform/build.gradle.kts
@@ -17,12 +17,9 @@ version = properties["version"] as String
 kotlin {
   applyDefaultHierarchyTemplate()
   explicitApi()
+  jvmToolchain(17)
 
-  jvm {
-    compilerOptions {
-      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-    }
-  }
+  jvm()
 
   listOf(
     iosArm64(),
@@ -108,12 +105,6 @@ multiplatformSwiftPackage {
   }
   packageName("TweetNaClMultiplatform")
   distributionMode { local() }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-  compilerOptions {
-    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-  }
 }
 
 signing {


### PR DESCRIPTION
Bumps to latest-stable across the Kotlin/SKIE/AGP/Gradle toolchain that
work together (SKIE 0.10.11 caps Kotlin at 2.3.20, so that's the pin):
- Kotlin 2.3.0 -> 2.3.20
- SKIE 0.10.9 -> 0.10.11
- AGP 9.0.1 -> 9.2.0 (catalog only; Android target lands in next change)
- Gradle 9.2.1 -> 9.4.1 (required by AGP 9.2.0)

Other hygiene:
- Move libs.versions.toml from repo root to gradle/ (Gradle convention)
- Drop now-obsolete kotlin.mpp.* properties (kept enableCInteropCommonization
  because the appleMain/nativeMain hierarchy still needs it for the TweetNaCl
  cinterop)
- Replace per-module 'tasks.withType<KotlinCompile> { jvmTarget = JVM_17 }'
  with 'kotlin { jvmToolchain(17) }' and add foojay-resolver-convention so
  Gradle auto-provisions JDK 17 when missing
- Remove unused libs from the catalog (khash, coreLibraryDesugaring,
  junitVintage, okhttp, okhttpLoggingInterceptor)
- Bump project version 0.4.5 -> 0.5.0