### PR TITLE
Add binary-compatibility-validator with KLIB validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,21 @@
 plugins {
   alias(libs.plugins.kotlinMultiplatform).apply(false)
   alias(libs.plugins.androidLib).apply(false)
+  alias(libs.plugins.binaryCompatibilityValidator)
   alias(libs.plugins.nmcp)
 }
 
 if (rootProject.findProperty("snapshot") == "true") {
   allprojects {
     version = "$version-SNAPSHOT"
+  }
+}
+
+apiValidation {
+  ignoredProjects += listOf("codegen")
+  @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
+  klib {
+    enabled = true
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidMinSdk = "24"
 androidCacheFix = "3.0.2"
 androidGradle = "9.2.0"
 androidJunit5 = "2.0.1"
+binaryCompatibilityValidator = "0.18.1"
 detekt = "1.23.8"
 jacoco = "0.8.7"
 kotlin = "2.3.20"
@@ -62,6 +63,7 @@ kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotli
 androidCacheFix = { id = "org.gradle.android.cache-fix", version.ref = "androidCacheFix" }
 androidJunit5 = { id = "de.mannodermaus.android-junit5", version.ref = "androidJunit5" }
 androidLib = { id = "com.android.library", version.ref = "androidGradle" }
+binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 cklib = { id = "co.touchlab.cklib", version = "0.3.5" }
 detekt = { id = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 detektFormatting = { id = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }

--- a/solana-kotlin-arrow-extensions/api/solana-kotlin-arrow-extensions.api
+++ b/solana-kotlin-arrow-extensions/api/solana-kotlin-arrow-extensions.api
@@ -1,0 +1,98 @@
+public final class net/avianlabs/solana/arrow/EitherKt {
+	public static final fun toEither (Lnet/avianlabs/solana/client/Response;)Larrow/core/Either;
+}
+
+public abstract interface class net/avianlabs/solana/arrow/SolanaKotlinError {
+}
+
+public final class net/avianlabs/solana/arrow/SolanaKotlinError$MalformedResponse : net/avianlabs/solana/arrow/SolanaKotlinError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$MalformedResponse;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/arrow/SolanaKotlinError$MalformedResponse;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$MalformedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class net/avianlabs/solana/arrow/SolanaKotlinError$RpcError : net/avianlabs/solana/arrow/SolanaKotlinError {
+}
+
+public final class net/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InternalError : net/avianlabs/solana/arrow/SolanaKotlinError$RpcError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InternalError;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InternalError;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InternalError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InvalidParams : net/avianlabs/solana/arrow/SolanaKotlinError$RpcError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InvalidParams;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InvalidParams;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InvalidParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InvalidRequest : net/avianlabs/solana/arrow/SolanaKotlinError$RpcError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InvalidRequest;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InvalidRequest;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$InvalidRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/arrow/SolanaKotlinError$RpcError$MethodNotFound : net/avianlabs/solana/arrow/SolanaKotlinError$RpcError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$MethodNotFound;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$MethodNotFound;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$MethodNotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/arrow/SolanaKotlinError$RpcError$ParseError : net/avianlabs/solana/arrow/SolanaKotlinError$RpcError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$ParseError;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$ParseError;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$ParseError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/arrow/SolanaKotlinError$RpcError$ServerError : net/avianlabs/solana/arrow/SolanaKotlinError$RpcError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$ServerError;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$ServerError;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$RpcError$ServerError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/arrow/SolanaKotlinError$UnknownError : net/avianlabs/solana/arrow/SolanaKotlinError {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$UnknownError;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/arrow/SolanaKotlinError$UnknownError;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/arrow/SolanaKotlinError$UnknownError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/solana-kotlin-arrow-extensions/api/solana-kotlin-arrow-extensions.klib.api
+++ b/solana-kotlin-arrow-extensions/api/solana-kotlin-arrow-extensions.klib.api
@@ -1,0 +1,117 @@
+// Klib ABI Dump
+// Targets: [linuxX64, mingwX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <net.avianlabs.solana:solana-kotlin-arrow-extensions>
+sealed interface net.avianlabs.solana.arrow/SolanaKotlinError { // net.avianlabs.solana.arrow/SolanaKotlinError|null[0]
+    sealed interface RpcError : net.avianlabs.solana.arrow/SolanaKotlinError { // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError|null[0]
+        final class InternalError : net.avianlabs.solana.arrow/SolanaKotlinError.RpcError { // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError|null[0]
+            constructor <init>(kotlin/String) // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError.<init>|<init>(kotlin.String){}[0]
+
+            final val message // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError.message|{}message[0]
+                final fun <get-message>(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError.message.<get-message>|<get-message>(){}[0]
+
+            final fun component1(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError.component1|component1(){}[0]
+            final fun copy(kotlin/String = ...): net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError.copy|copy(kotlin.String){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InternalError.toString|toString(){}[0]
+        }
+
+        final class InvalidParams : net.avianlabs.solana.arrow/SolanaKotlinError.RpcError { // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams|null[0]
+            constructor <init>(kotlin/String) // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams.<init>|<init>(kotlin.String){}[0]
+
+            final val message // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams.message|{}message[0]
+                final fun <get-message>(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams.message.<get-message>|<get-message>(){}[0]
+
+            final fun component1(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams.component1|component1(){}[0]
+            final fun copy(kotlin/String = ...): net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams.copy|copy(kotlin.String){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidParams.toString|toString(){}[0]
+        }
+
+        final class InvalidRequest : net.avianlabs.solana.arrow/SolanaKotlinError.RpcError { // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest|null[0]
+            constructor <init>(kotlin/String) // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest.<init>|<init>(kotlin.String){}[0]
+
+            final val message // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest.message|{}message[0]
+                final fun <get-message>(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest.message.<get-message>|<get-message>(){}[0]
+
+            final fun component1(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest.component1|component1(){}[0]
+            final fun copy(kotlin/String = ...): net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest.copy|copy(kotlin.String){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.InvalidRequest.toString|toString(){}[0]
+        }
+
+        final class MethodNotFound : net.avianlabs.solana.arrow/SolanaKotlinError.RpcError { // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound|null[0]
+            constructor <init>(kotlin/String) // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound.<init>|<init>(kotlin.String){}[0]
+
+            final val message // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound.message|{}message[0]
+                final fun <get-message>(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound.message.<get-message>|<get-message>(){}[0]
+
+            final fun component1(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound.component1|component1(){}[0]
+            final fun copy(kotlin/String = ...): net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound.copy|copy(kotlin.String){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.MethodNotFound.toString|toString(){}[0]
+        }
+
+        final class ParseError : net.avianlabs.solana.arrow/SolanaKotlinError.RpcError { // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError|null[0]
+            constructor <init>(kotlin/String) // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError.<init>|<init>(kotlin.String){}[0]
+
+            final val message // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError.message|{}message[0]
+                final fun <get-message>(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError.message.<get-message>|<get-message>(){}[0]
+
+            final fun component1(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError.component1|component1(){}[0]
+            final fun copy(kotlin/String = ...): net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError.copy|copy(kotlin.String){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ParseError.toString|toString(){}[0]
+        }
+
+        final class ServerError : net.avianlabs.solana.arrow/SolanaKotlinError.RpcError { // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError|null[0]
+            constructor <init>(kotlin/String) // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError.<init>|<init>(kotlin.String){}[0]
+
+            final val message // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError.message|{}message[0]
+                final fun <get-message>(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError.message.<get-message>|<get-message>(){}[0]
+
+            final fun component1(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError.component1|component1(){}[0]
+            final fun copy(kotlin/String = ...): net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError.copy|copy(kotlin.String){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.RpcError.ServerError.toString|toString(){}[0]
+        }
+    }
+
+    final class MalformedResponse : net.avianlabs.solana.arrow/SolanaKotlinError { // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse|null[0]
+        constructor <init>(kotlin/String) // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse.<init>|<init>(kotlin.String){}[0]
+
+        final val message // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse.message|{}message[0]
+            final fun <get-message>(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse.message.<get-message>|<get-message>(){}[0]
+
+        final fun component1(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.MalformedResponse.toString|toString(){}[0]
+    }
+
+    final class UnknownError : net.avianlabs.solana.arrow/SolanaKotlinError { // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError|null[0]
+        constructor <init>(kotlin/String) // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError.<init>|<init>(kotlin.String){}[0]
+
+        final val message // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError.message|{}message[0]
+            final fun <get-message>(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError.message.<get-message>|<get-message>(){}[0]
+
+        final fun component1(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.arrow/SolanaKotlinError.UnknownError.toString|toString(){}[0]
+    }
+}
+
+final fun <#A: kotlin/Any?> (net.avianlabs.solana.client/Response<#A>).net.avianlabs.solana.arrow/toEither(): arrow.core/Either<net.avianlabs.solana.arrow/SolanaKotlinError, #A> // net.avianlabs.solana.arrow/toEither|toEither@net.avianlabs.solana.client.Response<0:0>(){0§<kotlin.Any?>}[0]

--- a/solana-kotlin/api/solana-kotlin.api
+++ b/solana-kotlin/api/solana-kotlin.api
@@ -1,0 +1,2387 @@
+public final class net/avianlabs/solana/SolanaClient {
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/avianlabs/solana/client/RpcKtorClient;Ljava/util/Map;)V
+	public synthetic fun <init> (Lnet/avianlabs/solana/client/RpcKtorClient;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class net/avianlabs/solana/client/HttpRequestExecutorConfig {
+	public static final field Companion Lnet/avianlabs/solana/client/HttpRequestExecutorConfig$Companion;
+	public static final field version Ljava/lang/String;
+	public fun <init> (Lio/ktor/http/Url;)V
+	public final fun component1 ()Lio/ktor/http/Url;
+	public final fun copy (Lio/ktor/http/Url;)Lnet/avianlabs/solana/client/HttpRequestExecutorConfig;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/client/HttpRequestExecutorConfig;Lio/ktor/http/Url;ILjava/lang/Object;)Lnet/avianlabs/solana/client/HttpRequestExecutorConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseURL ()Lio/ktor/http/Url;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/client/HttpRequestExecutorConfig$Companion {
+}
+
+public final class net/avianlabs/solana/client/RequestIdGenerator {
+	public fun <init> ()V
+	public final fun next ()I
+}
+
+public final class net/avianlabs/solana/client/Response {
+	public static final field Companion Lnet/avianlabs/solana/client/Response$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/Object;Lnet/avianlabs/solana/client/RpcError;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Object;Lnet/avianlabs/solana/client/RpcError;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun component4 ()Lnet/avianlabs/solana/client/RpcError;
+	public final fun copy (ILjava/lang/String;Ljava/lang/Object;Lnet/avianlabs/solana/client/RpcError;)Lnet/avianlabs/solana/client/Response;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/client/Response;ILjava/lang/String;Ljava/lang/Object;Lnet/avianlabs/solana/client/RpcError;ILjava/lang/Object;)Lnet/avianlabs/solana/client/Response;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Lnet/avianlabs/solana/client/RpcError;
+	public final fun getId ()I
+	public final fun getJsonrpc ()Ljava/lang/String;
+	public final fun getResult ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/client/Response$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/client/Response;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/client/Response;)V
+	public final fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/client/Response$Companion {
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/client/Response$RPC {
+	public static final field Companion Lnet/avianlabs/solana/client/Response$RPC$Companion;
+	public fun <init> (Lnet/avianlabs/solana/client/Response$RPC$Context;Ljava/lang/Object;)V
+	public final fun component1 ()Lnet/avianlabs/solana/client/Response$RPC$Context;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lnet/avianlabs/solana/client/Response$RPC$Context;Ljava/lang/Object;)Lnet/avianlabs/solana/client/Response$RPC;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/client/Response$RPC;Lnet/avianlabs/solana/client/Response$RPC$Context;Ljava/lang/Object;ILjava/lang/Object;)Lnet/avianlabs/solana/client/Response$RPC;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContext ()Lnet/avianlabs/solana/client/Response$RPC$Context;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/client/Response$RPC$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/client/Response$RPC;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/client/Response$RPC;)V
+	public final fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/client/Response$RPC$Companion {
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/client/Response$RPC$Context {
+	public static final field Companion Lnet/avianlabs/solana/client/Response$RPC$Context$Companion;
+	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-s-VKNKU ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy-4PLdz1A (JLjava/lang/String;)Lnet/avianlabs/solana/client/Response$RPC$Context;
+	public static synthetic fun copy-4PLdz1A$default (Lnet/avianlabs/solana/client/Response$RPC$Context;JLjava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/client/Response$RPC$Context;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApiVersion ()Ljava/lang/String;
+	public final fun getSlot-s-VKNKU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/client/Response$RPC$Context$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/client/Response$RPC$Context$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/client/Response$RPC$Context;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/client/Response$RPC$Context;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/client/Response$RPC$Context$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class net/avianlabs/solana/client/ResultParserError : java/lang/Throwable {
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class net/avianlabs/solana/client/RpcError {
+	public static final field Companion Lnet/avianlabs/solana/client/RpcError$Companion;
+	public fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;ILkotlinx/serialization/json/JsonObject;)Lnet/avianlabs/solana/client/RpcError;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/client/RpcError;Ljava/lang/String;ILkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lnet/avianlabs/solana/client/RpcError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()I
+	public final fun getData ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/client/RpcError$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/client/RpcError$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/client/RpcError;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/client/RpcError;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/client/RpcError$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/client/RpcInvocation {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;)Lnet/avianlabs/solana/client/RpcInvocation;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/client/RpcInvocation;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lnet/avianlabs/solana/client/RpcInvocation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeaderProviders ()Ljava/util/Map;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getParams ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/client/RpcKtorClient {
+	public fun <init> (Lio/ktor/http/Url;Lio/ktor/client/HttpClient;)V
+	public synthetic fun <init> (Lio/ktor/http/Url;Lio/ktor/client/HttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lio/ktor/client/HttpClient;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/ktor/client/HttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class net/avianlabs/solana/client/RpcRequest {
+	public fun <init> (Ljava/lang/Integer;Lnet/avianlabs/solana/client/RpcInvocation;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Lnet/avianlabs/solana/client/RpcInvocation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Lnet/avianlabs/solana/client/RpcInvocation;
+	public final fun copy (Ljava/lang/Integer;Lnet/avianlabs/solana/client/RpcInvocation;)Lnet/avianlabs/solana/client/RpcRequest;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/client/RpcRequest;Ljava/lang/Integer;Lnet/avianlabs/solana/client/RpcInvocation;ILjava/lang/Object;)Lnet/avianlabs/solana/client/RpcRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/Integer;
+	public final fun getInvocation ()Lnet/avianlabs/solana/client/RpcInvocation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class net/avianlabs/solana/client/RpcResult {
+}
+
+public final class net/avianlabs/solana/domain/core/AccountMeta {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZZ)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZZ)Lnet/avianlabs/solana/domain/core/AccountMeta;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/AccountMeta;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZZILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/AccountMeta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPublicKey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public final fun isSigner ()Z
+	public final fun isWritable ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/AddressLookupTableAccount {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;)Lnet/avianlabs/solana/domain/core/AddressLookupTableAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/AddressLookupTableAccount;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/AddressLookupTableAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddresses ()Ljava/util/List;
+	public final fun getKey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/Commitment : java/lang/Enum {
+	public static final field Confirmed Lnet/avianlabs/solana/domain/core/Commitment;
+	public static final field Finalized Lnet/avianlabs/solana/domain/core/Commitment;
+	public static final field Processed Lnet/avianlabs/solana/domain/core/Commitment;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/Commitment;
+	public static fun values ()[Lnet/avianlabs/solana/domain/core/Commitment;
+}
+
+public abstract class net/avianlabs/solana/domain/core/DecodedInstruction {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getProgram ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+}
+
+public abstract class net/avianlabs/solana/domain/core/DecodedInstruction$AssociatedTokenProgram : net/avianlabs/solana/domain/core/DecodedInstruction {
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$AssociatedTokenProgram$CreatedAssociatedAccount : net/avianlabs/solana/domain/core/DecodedInstruction$AssociatedTokenProgram {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component4 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component5 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$AssociatedTokenProgram$CreatedAssociatedAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$AssociatedTokenProgram$CreatedAssociatedAccount;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$AssociatedTokenProgram$CreatedAssociatedAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssociatedAccount ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getMint ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getOwner ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getPayer ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$Raw : net/avianlabs/solana/domain/core/DecodedInstruction {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;[B)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()[B
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;[B)Lnet/avianlabs/solana/domain/core/DecodedInstruction$Raw;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$Raw;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;[BILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$Raw;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccounts ()Ljava/util/List;
+	public final fun getData ()[B
+	public fun getProgram ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram : net/avianlabs/solana/domain/core/DecodedInstruction {
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getProgramIndex-pVg5ArA ()I
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$AdvanceNonceAccount : net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$AdvanceNonceAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$AdvanceNonceAccount;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$AdvanceNonceAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthorizedPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getNonceAccount ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$AuthorizeNonceAccount : net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$AuthorizeNonceAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$AuthorizeNonceAccount;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$AuthorizeNonceAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthorizedPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getNewAuthorizedPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getNonceAccount ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$CreateAccount : net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JJLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JJLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$CreateAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$CreateAccount;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JJLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$CreateAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrom ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getLamports ()J
+	public final fun getNewAccount ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getOwner ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSpace ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$InitializeNonceAccount : net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$InitializeNonceAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$InitializeNonceAccount;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$InitializeNonceAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthorizedPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getNonceAccount ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$Transfer : net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()J
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$Transfer;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$Transfer;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$Transfer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrom ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getLamports ()J
+	public final fun getTo ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$WithdrawNonceAccount : net/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component4 ()J
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$WithdrawNonceAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$WithdrawNonceAccount;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$SystemProgram$WithdrawNonceAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthorizedPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getDestination ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getLamports ()J
+	public final fun getNonceAccount ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class net/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram : net/avianlabs/solana/domain/core/DecodedInstruction {
+	public synthetic fun <init> (BLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getProgramIndex-w2LRezQ ()B
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram$Transfer : net/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component4 ()J
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram$Transfer;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram$Transfer;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram$Transfer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()J
+	public final fun getDestination ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getOwner ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSource ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram$TransferChecked : net/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JBLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component4 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component5 ()J
+	public final fun component6-w2LRezQ ()B
+	public final fun copy-Q1Gd0Rw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram$TransferChecked;
+	public static synthetic fun copy-Q1Gd0Rw$default (Lnet/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram$TransferChecked;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JBILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedInstruction$TokenProgram$TransferChecked;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()J
+	public final fun getDecimals-w2LRezQ ()B
+	public final fun getDestination ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getMint ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getOwner ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSource ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedTransaction {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lnet/avianlabs/solana/domain/core/DecodedTransaction;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/DecodedTransaction;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/DecodedTransaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInstructions ()Ljava/util/List;
+	public final fun getSignatures ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/DecodedTransactionKt {
+	public static final fun decode (Lnet/avianlabs/solana/methods/TransactionResponse;)Lnet/avianlabs/solana/domain/core/DecodedTransaction;
+}
+
+public final class net/avianlabs/solana/domain/core/DeserializeVersionedMessageKt {
+	public static final fun deserialize (Lnet/avianlabs/solana/domain/core/VersionedMessage$Companion;[B)Lnet/avianlabs/solana/domain/core/VersionedMessage;
+}
+
+public final class net/avianlabs/solana/domain/core/FeeCalculator {
+	public static final field Companion Lnet/avianlabs/solana/domain/core/FeeCalculator$Companion;
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-s-VKNKU ()J
+	public final fun copy-VKZWuLQ (J)Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public static synthetic fun copy-VKZWuLQ$default (Lnet/avianlabs/solana/domain/core/FeeCalculator;JILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLamportsPerSignature-s-VKNKU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/domain/core/FeeCalculator$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/core/FeeCalculator$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/domain/core/FeeCalculator;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/domain/core/FeeCalculator$Companion {
+	public final fun read (Lokio/BufferedSource;)Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/domain/core/Message {
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountKeys ()Ljava/util/List;
+	public final fun getFeePayer ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getInstructions ()Ljava/util/List;
+	public final fun getRecentBlockHash ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun newBuilder ()Lnet/avianlabs/solana/domain/core/Message$Builder;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/Message$Builder {
+	public fun <init> ()V
+	public final fun addInstruction (Lnet/avianlabs/solana/domain/core/TransactionInstruction;)Lnet/avianlabs/solana/domain/core/Message$Builder;
+	public final fun build ()Lnet/avianlabs/solana/domain/core/Message;
+	public final fun setFeePayer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/Message$Builder;
+	public final fun setRecentBlockHash (Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/Message$Builder;
+}
+
+public final class net/avianlabs/solana/domain/core/MessageAddressTableLookup {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;Ljava/util/List;)Lnet/avianlabs/solana/domain/core/MessageAddressTableLookup;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/MessageAddressTableLookup;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/MessageAddressTableLookup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountKey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getReadonlyIndexes ()Ljava/util/List;
+	public final fun getWritableIndexes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/NonceAccountData {
+	public static final field Companion Lnet/avianlabs/solana/domain/core/NonceAccountData$Companion;
+	public synthetic fun <init> (IILnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-pVg5ArA ()I
+	public final fun component2-pVg5ArA ()I
+	public final fun component3 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public final fun copy-vdE3YOs (IILnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;)Lnet/avianlabs/solana/domain/core/NonceAccountData;
+	public static synthetic fun copy-vdE3YOs$default (Lnet/avianlabs/solana/domain/core/NonceAccountData;IILnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/NonceAccountData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthorizedPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getFeeCalculator ()Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public final fun getNonce ()Ljava/lang/String;
+	public final fun getState-pVg5ArA ()I
+	public final fun getVersion-pVg5ArA ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/NonceAccountData$Companion {
+	public final fun read (Lokio/BufferedSource;)Lnet/avianlabs/solana/domain/core/NonceAccountData;
+}
+
+public final class net/avianlabs/solana/domain/core/PublicKeyKt {
+	public static final fun read (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey$Companion;Lokio/BufferedSource;)Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+}
+
+public final class net/avianlabs/solana/domain/core/SerializeMessageKt {
+	public static final fun serialize (Lnet/avianlabs/solana/domain/core/Message;)[B
+}
+
+public final class net/avianlabs/solana/domain/core/SerializeVersionedMessageKt {
+	public static final fun serialize (Lnet/avianlabs/solana/domain/core/VersionedMessage;)[B
+}
+
+public final class net/avianlabs/solana/domain/core/SerializedTransaction {
+	public static final synthetic fun box-impl ([B)Lnet/avianlabs/solana/domain/core/SerializedTransaction;
+	public static fun constructor-impl ([B)[B
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl ([BLjava/lang/Object;)Z
+	public static final fun equals-impl0 ([B[B)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl ([B)I
+	public static final fun sign-44UhrVs ([BLjava/util/List;)[B
+	public static final fun sign-44UhrVs ([BLnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;)[B
+	public static final fun toByteArray-impl ([B)[B
+	public static final fun toSignedTransaction-impl ([B)Lnet/avianlabs/solana/domain/core/SignedTransaction;
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl ([B)Ljava/lang/String;
+	public static final fun toVersionedTransaction-impl ([B)Lnet/avianlabs/solana/domain/core/VersionedTransaction;
+	public final synthetic fun unbox-impl ()[B
+}
+
+public final class net/avianlabs/solana/domain/core/SignaturePubkeyPair {
+	public fun <init> (Ljava/lang/String;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Ljava/lang/String;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/SignaturePubkeyPair;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/SignaturePubkeyPair;Ljava/lang/String;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/SignaturePubkeyPair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPublicKey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSignature ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/SignaturePublicKeyPair {
+	public fun <init> ([BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()[B
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy ([BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/SignaturePublicKeyPair;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/SignaturePublicKeyPair;[BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/SignaturePublicKeyPair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPublicKey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSignature ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/SignedTransaction {
+	public static final field Companion Lnet/avianlabs/solana/domain/core/SignedTransaction$Companion;
+	public fun <init> (Lnet/avianlabs/solana/domain/core/VersionedMessage;[BLjava/util/Map;Ljava/util/List;)V
+	public final fun component1 ()Lnet/avianlabs/solana/domain/core/VersionedMessage;
+	public final fun component2 ()[B
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Lnet/avianlabs/solana/domain/core/VersionedMessage;[BLjava/util/Map;Ljava/util/List;)Lnet/avianlabs/solana/domain/core/SignedTransaction;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/SignedTransaction;Lnet/avianlabs/solana/domain/core/VersionedMessage;[BLjava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/SignedTransaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lnet/avianlabs/solana/domain/core/VersionedMessage;
+	public final fun getSerializedMessage ()[B
+	public final fun getSignatures ()Ljava/util/Map;
+	public final fun getSignerKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun serialize-44UhrVs (Z)[B
+	public static synthetic fun serialize-44UhrVs$default (Lnet/avianlabs/solana/domain/core/SignedTransaction;ZILjava/lang/Object;)[B
+	public final fun sign (Ljava/util/List;)Lnet/avianlabs/solana/domain/core/SignedTransaction;
+	public final fun sign (Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;)Lnet/avianlabs/solana/domain/core/SignedTransaction;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/SignedTransaction$Companion {
+	public final fun sign (Lnet/avianlabs/solana/domain/core/VersionedMessage;Ljava/util/List;)Lnet/avianlabs/solana/domain/core/SignedTransaction;
+}
+
+public final class net/avianlabs/solana/domain/core/Transaction {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lnet/avianlabs/solana/domain/core/Message;
+	public fun hashCode ()I
+	public final fun newBuilder ()Lnet/avianlabs/solana/domain/core/Transaction$Builder;
+	public final fun sign (Ljava/util/List;)Lnet/avianlabs/solana/domain/core/SignedTransaction;
+	public final fun sign (Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;)Lnet/avianlabs/solana/domain/core/SignedTransaction;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/Transaction$Builder {
+	public fun <init> ()V
+	public final fun addInstruction (Lnet/avianlabs/solana/domain/core/TransactionInstruction;)Lnet/avianlabs/solana/domain/core/Transaction$Builder;
+	public final fun build ()Lnet/avianlabs/solana/domain/core/Transaction;
+	public final fun setFeePayer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/Transaction$Builder;
+	public final fun setRecentBlockHash (Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/Transaction$Builder;
+}
+
+public final class net/avianlabs/solana/domain/core/TransactionInstruction {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;[B)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()[B
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;[B)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/TransactionInstruction;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;[BILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()[B
+	public final fun getKeys ()Ljava/util/List;
+	public final fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class net/avianlabs/solana/domain/core/VersionedMessage {
+	public static final field Companion Lnet/avianlabs/solana/domain/core/VersionedMessage$Companion;
+	public abstract fun getFeePayer ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public abstract fun getInstructions ()Ljava/util/List;
+	public abstract fun getRecentBlockHash ()Ljava/lang/String;
+	public abstract fun getStaticAccountKeys ()Ljava/util/List;
+}
+
+public final class net/avianlabs/solana/domain/core/VersionedMessage$Companion {
+}
+
+public final class net/avianlabs/solana/domain/core/VersionedMessage$Legacy : net/avianlabs/solana/domain/core/VersionedMessage {
+	public fun <init> (Lnet/avianlabs/solana/domain/core/Message;)V
+	public final fun component1 ()Lnet/avianlabs/solana/domain/core/Message;
+	public final fun copy (Lnet/avianlabs/solana/domain/core/Message;)Lnet/avianlabs/solana/domain/core/VersionedMessage$Legacy;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/VersionedMessage$Legacy;Lnet/avianlabs/solana/domain/core/Message;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/VersionedMessage$Legacy;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFeePayer ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun getInstructions ()Ljava/util/List;
+	public final fun getMessage ()Lnet/avianlabs/solana/domain/core/Message;
+	public fun getRecentBlockHash ()Ljava/lang/String;
+	public fun getStaticAccountKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/VersionedMessage$V0 : net/avianlabs/solana/domain/core/VersionedMessage {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lnet/avianlabs/solana/domain/core/VersionedMessage$V0;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/core/VersionedMessage$V0;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/VersionedMessage$V0;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddressTableLookups ()Ljava/util/List;
+	public fun getFeePayer ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun getInstructions ()Ljava/util/List;
+	public fun getRecentBlockHash ()Ljava/lang/String;
+	public fun getStaticAccountKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/VersionedTransaction {
+	public static final field Companion Lnet/avianlabs/solana/domain/core/VersionedTransaction$Companion;
+	public fun <init> (Lnet/avianlabs/solana/domain/core/VersionedMessage;Ljava/util/Map;)V
+	public synthetic fun <init> (Lnet/avianlabs/solana/domain/core/VersionedMessage;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lnet/avianlabs/solana/domain/core/VersionedMessage;
+	public final fun getSerializedMessage ()[B
+	public final fun getSignatures ()Ljava/util/Map;
+	public final fun getSignerKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun serialize-aITdtFI ()[B
+	public final fun sign (Ljava/util/List;)Lnet/avianlabs/solana/domain/core/VersionedTransaction;
+	public final fun sign (Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;)Lnet/avianlabs/solana/domain/core/VersionedTransaction;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/core/VersionedTransaction$Builder {
+	public fun <init> ()V
+	public final fun addAddressLookupTableAccount (Lnet/avianlabs/solana/domain/core/AddressLookupTableAccount;)Lnet/avianlabs/solana/domain/core/VersionedTransaction$Builder;
+	public final fun addInstruction (Lnet/avianlabs/solana/domain/core/TransactionInstruction;)Lnet/avianlabs/solana/domain/core/VersionedTransaction$Builder;
+	public final fun build ()Lnet/avianlabs/solana/domain/core/VersionedTransaction;
+	public final fun buildLegacy ()Lnet/avianlabs/solana/domain/core/VersionedTransaction;
+	public final fun buildV0 ()Lnet/avianlabs/solana/domain/core/VersionedTransaction;
+	public final fun setFeePayer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/VersionedTransaction$Builder;
+	public final fun setRecentBlockHash (Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/VersionedTransaction$Builder;
+}
+
+public final class net/avianlabs/solana/domain/core/VersionedTransaction$Companion {
+	public final fun deserialize ([B)Lnet/avianlabs/solana/domain/core/VersionedTransaction;
+}
+
+public final class net/avianlabs/solana/domain/program/AssociatedTokenExtKt {
+	public static final fun associatedTokenAddress (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/ProgramDerivedAddress;
+	public static synthetic fun associatedTokenAddress$default (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/ProgramDerivedAddress;
+}
+
+public final class net/avianlabs/solana/domain/program/AssociatedTokenProgram : net/avianlabs/solana/domain/program/Program {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram;
+	public final fun createAssociatedToken (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun createAssociatedToken$default (Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun createAssociatedTokenAccountInstruction (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun createAssociatedTokenAccountInstruction$default (Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun createAssociatedTokenAccountInstructionIdempotent (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun createAssociatedTokenAccountInstructionIdempotent$default (Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun createAssociatedTokenIdempotent (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun createAssociatedTokenIdempotent$default (Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun recoverNestedAssociatedToken (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun recoverNestedAssociatedToken$default (Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+}
+
+public final class net/avianlabs/solana/domain/program/AssociatedTokenProgram$Instruction : java/lang/Enum {
+	public static final field CreateAssociatedToken Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram$Instruction;
+	public static final field CreateAssociatedTokenIdempotent Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram$Instruction;
+	public static final field RecoverNestedAssociatedToken Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram$Instruction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getIndex-w2LRezQ ()B
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram$Instruction;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/AssociatedTokenProgram$Instruction;
+}
+
+public final class net/avianlabs/solana/domain/program/ComputeBudgetProgram : net/avianlabs/solana/domain/program/Program {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/ComputeBudgetProgram;
+	public fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun requestHeapFrame-WZ4Q5Ns (I)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun requestUnits-feOb9K0 (II)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun setComputeUnitLimit-WZ4Q5Ns (I)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun setComputeUnitPrice-VKZWuLQ (J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun setLoadedAccountsDataSizeLimit-WZ4Q5Ns (I)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+}
+
+public final class net/avianlabs/solana/domain/program/ComputeBudgetProgram$Instruction : java/lang/Enum {
+	public static final field RequestHeapFrame Lnet/avianlabs/solana/domain/program/ComputeBudgetProgram$Instruction;
+	public static final field RequestUnits Lnet/avianlabs/solana/domain/program/ComputeBudgetProgram$Instruction;
+	public static final field SetComputeUnitLimit Lnet/avianlabs/solana/domain/program/ComputeBudgetProgram$Instruction;
+	public static final field SetComputeUnitPrice Lnet/avianlabs/solana/domain/program/ComputeBudgetProgram$Instruction;
+	public static final field SetLoadedAccountsDataSizeLimit Lnet/avianlabs/solana/domain/program/ComputeBudgetProgram$Instruction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getIndex-w2LRezQ ()B
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/ComputeBudgetProgram$Instruction;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/ComputeBudgetProgram$Instruction;
+}
+
+public abstract interface class net/avianlabs/solana/domain/program/Program {
+	public static final field Companion Lnet/avianlabs/solana/domain/program/Program$Companion;
+	public abstract fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+}
+
+public final class net/avianlabs/solana/domain/program/Program$Companion {
+	public final fun findProgramAddress (Ljava/util/List;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/ProgramDerivedAddress;
+}
+
+public final class net/avianlabs/solana/domain/program/ProgramDerivedAddress {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2-w2LRezQ ()B
+	public final fun copy-EK-6454 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;B)Lnet/avianlabs/solana/domain/program/ProgramDerivedAddress;
+	public static synthetic fun copy-EK-6454$default (Lnet/avianlabs/solana/domain/program/ProgramDerivedAddress;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/ProgramDerivedAddress;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getNonce-w2LRezQ ()B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/SystemProgram : net/avianlabs/solana/domain/program/Program {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/SystemProgram;
+	public final fun advanceNonceAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun advanceNonceAccount$default (Lnet/avianlabs/solana/domain/program/SystemProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun allocate-2TYgG_w (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun allocateWithSeed-7KREoTw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;JLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun assign (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun assignWithSeed (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun authorizeNonceAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun createAccount-orKg6c4 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JJLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun createAccountWithSeed-eejtpB4 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;JJLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun getNONCE_ACCOUNT_LENGTH ()J
+	public final fun getNONCE_LENGTH ()J
+	public fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getRECENT_BLOCKHASHES_SYSVAR ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getRENT_SYSVAR ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSYSVAR_RECENT_BLOCKHASH ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSYSVAR_RENT_ACCOUNT ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun initializeNonceAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun initializeNonceAccount$default (Lnet/avianlabs/solana/domain/program/SystemProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun nonceAdvance (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun nonceAdvance$default (Lnet/avianlabs/solana/domain/program/SystemProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun nonceInitialize (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun transfer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun transferSol-aPcrCvc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun transferSolWithSeed-EC5Vqqo (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLjava/lang/String;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun upgradeNonceAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun withdrawNonceAccount-EC5Vqqo (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun withdrawNonceAccount-EC5Vqqo$default (Lnet/avianlabs/solana/domain/program/SystemProgram;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+}
+
+public final class net/avianlabs/solana/domain/program/SystemProgram$Instruction : java/lang/Enum {
+	public static final field AdvanceNonceAccount Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field Allocate Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field AllocateWithSeed Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field Assign Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field AssignWithSeed Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field AuthorizeNonceAccount Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field CreateAccount Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field CreateAccountWithSeed Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field InitializeNonceAccount Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field TransferSol Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field TransferSolWithSeed Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field UpgradeNonceAccount Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static final field WithdrawNonceAccount Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getIndex-pVg5ArA ()I
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/SystemProgram$Instruction;
+}
+
+public final class net/avianlabs/solana/domain/program/SystemProgram$NonceState : java/lang/Enum {
+	public static final field Initialized Lnet/avianlabs/solana/domain/program/SystemProgram$NonceState;
+	public static final field Uninitialized Lnet/avianlabs/solana/domain/program/SystemProgram$NonceState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue-pVg5ArA ()I
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/SystemProgram$NonceState;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/SystemProgram$NonceState;
+}
+
+public final class net/avianlabs/solana/domain/program/SystemProgram$NonceVersion : java/lang/Enum {
+	public static final field Current Lnet/avianlabs/solana/domain/program/SystemProgram$NonceVersion;
+	public static final field Legacy Lnet/avianlabs/solana/domain/program/SystemProgram$NonceVersion;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue-pVg5ArA ()I
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/SystemProgram$NonceVersion;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/SystemProgram$NonceVersion;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program : net/avianlabs/solana/domain/program/TokenProgram {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program;
+	public fun amountToUiAmount-2TYgG_w (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun applyConfidentialPendingBalance-DIYrhD4 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J[B)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun approve-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun approveChecked-TpV2jgs (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun approveConfidentialTransferAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun burn-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun burnChecked-uay8ffw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun closeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun confidentialDeposit-uay8ffw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun confidentialTransfer-t-QCEoQ (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[BBBB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun confidentialTransferWithFee-ePTVXeY (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[BBBBBB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun confidentialWithdraw-g_eu1SI (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB[BBB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun configureConfidentialTransferAccount-5LldxOQ (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[BJBLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun configureConfidentialTransferAccount-5LldxOQ$default (Lnet/avianlabs/solana/domain/program/Token2022Program;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[BJBLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun createNativeMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun createNativeMint$default (Lnet/avianlabs/solana/domain/program/Token2022Program;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun disableConfidentialCredits (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun disableCpiGuard (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun disableHarvestToMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun disableMemoTransfers (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun disableNonConfidentialCredits (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun emitTokenMetadata-66RPfx8 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lkotlin/ULong;Lkotlin/ULong;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun emptyConfidentialTransferAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun emptyConfidentialTransferAccount$default (Lnet/avianlabs/solana/domain/program/Token2022Program;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun enableConfidentialCredits (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun enableCpiGuard (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun enableHarvestToMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun enableMemoTransfers (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun enableNonConfidentialCredits (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun freezeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun getAccountDataSize (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun getINSTRUCTIONS_SYSVAR_OR_CONTEXT_STATE ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getMULTISIG_LENGTH ()J
+	public fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getRENT ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun harvestWithheldTokensToMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun harvestWithheldTokensToMintForConfidentialTransferFee (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeAccount2 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeAccount3 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeConfidentialTransferFee (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeConfidentialTransferMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeDefaultAccountState (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeGroupMemberPointer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeGroupPointer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeImmutableOwner (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeInterestBearingMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;S)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeMetadataPointer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeMint-i5x2l0M (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeMint2-srPc2dE (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeMintCloseAuthority (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeMultisig-Zo7BePA (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeMultisig2-EK-6454 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;B)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeNonTransferableMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializePausableConfig (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializePermanentDelegate (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeScaledUiAmountMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;D)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeTokenGroup-WQ083AA (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeTokenGroupMember (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeTokenMetadata (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeTransferFeeConfig-IBBZpns (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;SJ)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun initializeTransferHook (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun mintTo-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun mintToChecked-uay8ffw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun pause (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun reallocate (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public static synthetic fun reallocate$default (Lnet/avianlabs/solana/domain/program/Token2022Program;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/util/List;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun removeTokenMetadataKey (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZLjava/lang/String;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun resume (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun revoke (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun setAuthority (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun setTransferFee-iw7Vnr0 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;SJ)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun syncNative (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun thawAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun transfer-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun transferChecked-TpV2jgs (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun transferCheckedWithFee-csFvPGA (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JBJ)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun uiAmountToAmount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun unwrapLamports-nRXsjtY (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lkotlin/ULong;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateConfidentialTransferMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateDefaultAccountState (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateGroupMemberPointer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateGroupPointer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateMetadataPointer (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateMultiplierScaledUiMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;DJ)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateRateInterestBearingMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;S)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateTokenGroupMaxSize-aPcrCvc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateTokenGroupUpdateAuthority (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateTokenMetadataField (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField;Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateTokenMetadataUpdateAuthority (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun updateTransferHook (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun withdrawExcessLamports (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun withdrawWithheldTokensFromAccounts-jDvRwcg (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;B)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun withdrawWithheldTokensFromAccountsForConfidentialTransferFee-5LfCyhE (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BB[B)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun withdrawWithheldTokensFromMint (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun withdrawWithheldTokensFromMintForConfidentialTransferFee-3_GkxP8 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;B[B)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$AccountState : java/lang/Enum {
+	public static final field Frozen Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;
+	public static final field Initialized Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;
+	public static final field Uninitialized Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue-w2LRezQ ()B
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$AuthorityType : java/lang/Enum {
+	public static final field AccountOwner Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field CloseAccount Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field CloseMint Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field ConfidentialTransferFeeConfig Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field ConfidentialTransferMint Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field FreezeAccount Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field GroupMemberPointer Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field GroupPointer Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field InterestRate Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field MetadataPointer Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field MintTokens Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field Pause Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field PermanentDelegate Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field ScaledUiAmount Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field TransferFeeConfig Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field TransferHookProgramId Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static final field WithheldWithdraw Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue-w2LRezQ ()B
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/Token2022Program$AuthorityType;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$DecryptableBalance {
+	public static final synthetic fun box-impl ([B)Lnet/avianlabs/solana/domain/program/Token2022Program$DecryptableBalance;
+	public static fun constructor-impl ([B)[B
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl ([BLjava/lang/Object;)Z
+	public static final fun equals-impl0 ([B[B)Z
+	public final fun getBytes ()[B
+	public fun hashCode ()I
+	public static fun hashCode-impl ([B)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl ([B)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$EncryptedBalance {
+	public static final synthetic fun box-impl ([B)Lnet/avianlabs/solana/domain/program/Token2022Program$EncryptedBalance;
+	public static fun constructor-impl ([B)[B
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl ([BLjava/lang/Object;)Z
+	public static final fun equals-impl0 ([B[B)Z
+	public final fun getBytes ()[B
+	public fun hashCode ()I
+	public static fun hashCode-impl ([B)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl ([B)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()[B
+}
+
+public abstract class net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public abstract fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialMintBurn : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialMintBurn;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferAccount : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> (ZLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[B[B[B[BZZJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10-s-VKNKU ()J
+	public final fun component11-s-VKNKU ()J
+	public final fun component12-s-VKNKU ()J
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3-z6cKho4 ()[B
+	public final fun component4-z6cKho4 ()[B
+	public final fun component5-z6cKho4 ()[B
+	public final fun component6-8LR2nuE ()[B
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9-s-VKNKU ()J
+	public final fun copy-GlPdeWs (ZLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[B[B[B[BZZJJJJ)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferAccount;
+	public static synthetic fun copy-GlPdeWs$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferAccount;ZLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[B[B[B[BZZJJJJILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActualPendingBalanceCreditCounter-s-VKNKU ()J
+	public final fun getAllowConfidentialCredits ()Z
+	public final fun getAllowNonConfidentialCredits ()Z
+	public final fun getApproved ()Z
+	public final fun getAvailableBalance-z6cKho4 ()[B
+	public final fun getDecryptableAvailableBalance-8LR2nuE ()[B
+	public final fun getElgamalPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getExpectedPendingBalanceCreditCounter-s-VKNKU ()J
+	public final fun getMaximumPendingBalanceCreditCounter-s-VKNKU ()J
+	public final fun getPendingBalanceCreditCounter-s-VKNKU ()J
+	public final fun getPendingBalanceHigh-z6cKho4 ()[B
+	public final fun getPendingBalanceLow-z6cKho4 ()[B
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferFee : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Z[BLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()Z
+	public final fun component4-z6cKho4 ()[B
+	public final fun copy-K7XWTnM (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Z[B)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferFee;
+	public static synthetic fun copy-K7XWTnM$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferFee;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Z[BILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferFee;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getElgamalPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getHarvestToMintEnabled ()Z
+	public final fun getWithheldAmount-z6cKho4 ()[B
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferFeeAmount : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> ([BLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-z6cKho4 ()[B
+	public final fun copy-Zvv2Pgs ([B)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferFeeAmount;
+	public static synthetic fun copy-Zvv2Pgs$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferFeeAmount;[BILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferFeeAmount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWithheldAmount-z6cKho4 ()[B
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferMint : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Z
+	public final fun component3 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferMint;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferMint;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ConfidentialTransferMint;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuditorElgamalPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getAutoApproveNewAccounts ()Z
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$CpiGuard : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$CpiGuard;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$CpiGuard;ZILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$CpiGuard;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLockCpi ()Z
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$DefaultAccountState : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;)V
+	public final fun component1 ()Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;
+	public final fun copy (Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$DefaultAccountState;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$DefaultAccountState;Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$DefaultAccountState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getState ()Lnet/avianlabs/solana/domain/program/Token2022Program$AccountState;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$GroupMemberPointer : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$GroupMemberPointer;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$GroupMemberPointer;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$GroupMemberPointer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getMemberAddress ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$GroupPointer : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$GroupPointer;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$GroupPointer;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$GroupPointer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getGroupAddress ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$ImmutableOwner : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ImmutableOwner;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$InterestBearingConfig : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JSJSLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2-s-VKNKU ()J
+	public final fun component3 ()S
+	public final fun component4-s-VKNKU ()J
+	public final fun component5 ()S
+	public final fun copy-QBHJvr0 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JSJS)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$InterestBearingConfig;
+	public static synthetic fun copy-QBHJvr0$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$InterestBearingConfig;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JSJSILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$InterestBearingConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrentRate ()S
+	public final fun getInitializationTimestamp-s-VKNKU ()J
+	public final fun getLastUpdateTimestamp-s-VKNKU ()J
+	public final fun getPreUpdateAverageRate ()S
+	public final fun getRateAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$MemoTransfer : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MemoTransfer;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MemoTransfer;ZILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MemoTransfer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequireIncomingTransferMemos ()Z
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$MetadataPointer : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MetadataPointer;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MetadataPointer;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MetadataPointer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getMetadataAddress ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$MintCloseAuthority : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MintCloseAuthority;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MintCloseAuthority;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$MintCloseAuthority;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCloseAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$NonTransferable : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$NonTransferable;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$NonTransferableAccount : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$NonTransferableAccount;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$PausableAccount : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$PausableAccount;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$PausableConfig : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Z)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Z
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Z)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$PausableConfig;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$PausableConfig;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ZILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$PausableConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getPaused ()Z
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$PermanentDelegate : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$PermanentDelegate;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$PermanentDelegate;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$PermanentDelegate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDelegate ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$ScaledUiAmountConfig : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;DJDLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()D
+	public final fun component3-s-VKNKU ()J
+	public final fun component4 ()D
+	public final fun copy-HFZJxNs (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;DJD)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ScaledUiAmountConfig;
+	public static synthetic fun copy-HFZJxNs$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ScaledUiAmountConfig;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;DJDILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$ScaledUiAmountConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getMultiplier ()D
+	public final fun getNewMultiplier ()D
+	public final fun getNewMultiplierEffectiveTimestamp-s-VKNKU ()J
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$TokenGroup : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3-s-VKNKU ()J
+	public final fun component4-s-VKNKU ()J
+	public final fun copy-RQJlUXk (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JJ)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenGroup;
+	public static synthetic fun copy-RQJlUXk$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenGroup;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JJILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenGroup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxSize-s-VKNKU ()J
+	public final fun getMint ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSize-s-VKNKU ()J
+	public final fun getUpdateAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$TokenGroupMember : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3-s-VKNKU ()J
+	public final fun copy-aPcrCvc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenGroupMember;
+	public static synthetic fun copy-aPcrCvc$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenGroupMember;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenGroupMember;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroup ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getMemberNumber-s-VKNKU ()J
+	public final fun getMint ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$TokenMetadata : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenMetadata;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenMetadata;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TokenMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdditionalMetadata ()Ljava/util/Map;
+	public final fun getMint ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSymbol ()Ljava/lang/String;
+	public final fun getUpdateAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$TransferFeeAmount : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-s-VKNKU ()J
+	public final fun copy-VKZWuLQ (J)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferFeeAmount;
+	public static synthetic fun copy-VKZWuLQ$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferFeeAmount;JILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferFeeAmount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWithheldAmount-s-VKNKU ()J
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$TransferFeeConfig : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public synthetic fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component3-s-VKNKU ()J
+	public final fun component4 ()Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;
+	public final fun component5 ()Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;
+	public final fun copy-bdvP6-E (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferFeeConfig;
+	public static synthetic fun copy-bdvP6-E$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferFeeConfig;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferFeeConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNewerTransferFee ()Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;
+	public final fun getOlderTransferFee ()Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;
+	public final fun getTransferFeeConfigAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getWithdrawWithheldAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getWithheldAmount-s-VKNKU ()J
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$TransferHook : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferHook;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferHook;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferHook;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$TransferHookAccount : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferHookAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferHookAccount;ZILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$TransferHookAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTransferring ()Z
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Extension$Uninitialized : net/avianlabs/solana/domain/program/Token2022Program$Extension {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$Extension$Uninitialized;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$ExtensionType : java/lang/Enum {
+	public static final field ConfidentialTransferAccount Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field ConfidentialTransferFee Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field ConfidentialTransferFeeAmount Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field ConfidentialTransferMint Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field CpiGuard Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field DefaultAccountState Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field GroupMemberPointer Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field GroupPointer Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field ImmutableOwner Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field InterestBearingConfig Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field MemoTransfer Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field MetadataPointer Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field MintCloseAuthority Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field NonTransferable Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field NonTransferableAccount Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field PausableAccount Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field PausableConfig Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field PermanentDelegate Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field ScaledUiAmountConfig Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field TokenGroup Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field TokenGroupMember Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field TokenMetadata Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field TransferFeeAmount Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field TransferFeeConfig Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field TransferHook Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field TransferHookAccount Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static final field Uninitialized Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue-Mh2AYeg ()S
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/Token2022Program$ExtensionType;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$Instruction : java/lang/Enum {
+	public static final field AmountToUiAmount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ApplyConfidentialPendingBalance Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field Approve Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ApproveChecked Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ApproveConfidentialTransferAccount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field Burn Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field BurnChecked Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field CloseAccount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ConfidentialDeposit Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ConfidentialTransfer Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ConfidentialTransferWithFee Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ConfidentialWithdraw Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ConfigureConfidentialTransferAccount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field CreateNativeMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field DisableConfidentialCredits Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field DisableCpiGuard Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field DisableHarvestToMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field DisableMemoTransfers Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field DisableNonConfidentialCredits Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field EmptyConfidentialTransferAccount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field EnableConfidentialCredits Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field EnableCpiGuard Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field EnableHarvestToMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field EnableMemoTransfers Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field EnableNonConfidentialCredits Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field FreezeAccount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field GetAccountDataSize Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field HarvestWithheldTokensToMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field HarvestWithheldTokensToMintForConfidentialTransferFee Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeAccount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeAccount2 Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeAccount3 Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeConfidentialTransferFee Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeConfidentialTransferMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeDefaultAccountState Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeGroupMemberPointer Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeGroupPointer Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeImmutableOwner Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeInterestBearingMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeMetadataPointer Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeMint2 Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeMintCloseAuthority Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeMultisig Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeMultisig2 Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeNonTransferableMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializePausableConfig Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializePermanentDelegate Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeScaledUiAmountMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeTransferFeeConfig Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field InitializeTransferHook Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field MintTo Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field MintToChecked Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field Pause Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field Reallocate Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field Resume Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field Revoke Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field SetAuthority Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field SetTransferFee Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field SyncNative Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field ThawAccount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field Transfer Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field TransferChecked Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field TransferCheckedWithFee Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UiAmountToAmount Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UnwrapLamports Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UpdateConfidentialTransferMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UpdateDefaultAccountState Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UpdateGroupMemberPointer Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UpdateGroupPointer Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UpdateMetadataPointer Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UpdateMultiplierScaledUiMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UpdateRateInterestBearingMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field UpdateTransferHook Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field WithdrawExcessLamports Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field WithdrawWithheldTokensFromAccounts Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field WithdrawWithheldTokensFromAccountsForConfidentialTransferFee Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field WithdrawWithheldTokensFromMint Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static final field WithdrawWithheldTokensFromMintForConfidentialTransferFee Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getIndex-w2LRezQ ()B
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/Token2022Program$Instruction;
+}
+
+public abstract class net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField {
+	public abstract fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Key : net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Key;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Key;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Key;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue0 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Name : net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Name;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Symbol : net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Symbol;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Uri : net/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField {
+	public static final field INSTANCE Lnet/avianlabs/solana/domain/program/Token2022Program$TokenMetadataField$Uri;
+	public fun serialize ()[B
+}
+
+public final class net/avianlabs/solana/domain/program/Token2022Program$TransferFee {
+	public synthetic fun <init> (JJSLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-s-VKNKU ()J
+	public final fun component2-s-VKNKU ()J
+	public final fun component3-Mh2AYeg ()S
+	public final fun copy-606-ukc (JJS)Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;
+	public static synthetic fun copy-606-ukc$default (Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;JJSILjava/lang/Object;)Lnet/avianlabs/solana/domain/program/Token2022Program$TransferFee;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEpoch-s-VKNKU ()J
+	public final fun getMaximumFee-s-VKNKU ()J
+	public final fun getTransferFeeBasisPoints-Mh2AYeg ()S
+	public fun hashCode ()I
+	public final fun serialize ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class net/avianlabs/solana/domain/program/TokenProgram : net/avianlabs/solana/domain/program/Program {
+	public static final field Companion Lnet/avianlabs/solana/domain/program/TokenProgram$Companion;
+	public abstract fun amountToUiAmount-2TYgG_w (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun approve-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun approveChecked-TpV2jgs (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun burn-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun burnChecked-uay8ffw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun closeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun freezeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun getAccountDataSize (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun initializeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun initializeAccount2 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun initializeAccount3 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun initializeImmutableOwner (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun initializeMint-i5x2l0M (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun initializeMint2-srPc2dE (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun initializeMultisig-Zo7BePA (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun initializeMultisig2-EK-6454 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;B)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun mintTo-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun mintToChecked-uay8ffw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun revoke (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun setAuthority (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun syncNative (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun thawAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun transfer-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun transferChecked-TpV2jgs (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public abstract fun uiAmountToAmount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+}
+
+public final class net/avianlabs/solana/domain/program/TokenProgram$AccountState : java/lang/Enum {
+	public static final field Frozen Lnet/avianlabs/solana/domain/program/TokenProgram$AccountState;
+	public static final field Initialized Lnet/avianlabs/solana/domain/program/TokenProgram$AccountState;
+	public static final field Uninitialized Lnet/avianlabs/solana/domain/program/TokenProgram$AccountState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue-w2LRezQ ()B
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/TokenProgram$AccountState;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/TokenProgram$AccountState;
+}
+
+public final class net/avianlabs/solana/domain/program/TokenProgram$AuthorityType : java/lang/Enum {
+	public static final field AccountOwner Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field CloseAccount Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field CloseMint Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field ConfidentialTransferFeeConfig Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field ConfidentialTransferMint Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field FreezeAccount Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field GroupMemberPointer Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field GroupPointer Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field InterestRate Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field MetadataPointer Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field MintTokens Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field Pause Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field PermanentDelegate Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field ScaledUiAmount Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field TransferFeeConfig Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field TransferHookProgramId Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static final field WithheldWithdraw Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue-w2LRezQ ()B
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;
+}
+
+public final class net/avianlabs/solana/domain/program/TokenProgram$Companion : net/avianlabs/solana/domain/program/TokenProgram {
+	public fun amountToUiAmount-2TYgG_w (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun approve-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun approveChecked-TpV2jgs (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun burn-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun burnChecked-uay8ffw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun closeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun freezeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun getAccountDataSize (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public final fun getMINT_LENGTH ()J
+	public final fun getMULTISIG_LENGTH ()J
+	public fun getProgramId ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getRENT ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getTOKEN_LENGTH ()J
+	public fun initializeAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeAccount2 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeAccount3 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeImmutableOwner (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeMint-i5x2l0M (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeMint2-srPc2dE (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeMultisig-Zo7BePA (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;BLnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun initializeMultisig2-EK-6454 (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;B)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun mintTo-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun mintToChecked-uay8ffw (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun revoke (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun setAuthority (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/program/TokenProgram$AuthorityType;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun syncNative (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun thawAccount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun transfer-ARK9YDc (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;J)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun transferChecked-TpV2jgs (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JB)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+	public fun uiAmountToAmount (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;)Lnet/avianlabs/solana/domain/core/TransactionInstruction;
+}
+
+public final class net/avianlabs/solana/domain/program/TokenProgram$Instruction : java/lang/Enum {
+	public static final field AmountToUiAmount Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field Approve Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field ApproveChecked Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field Burn Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field BurnChecked Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field CloseAccount Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field FreezeAccount Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field GetAccountDataSize Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field InitializeAccount Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field InitializeAccount2 Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field InitializeAccount3 Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field InitializeImmutableOwner Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field InitializeMint Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field InitializeMint2 Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field InitializeMultisig Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field InitializeMultisig2 Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field MintTo Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field MintToChecked Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field Revoke Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field SetAuthority Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field SyncNative Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field ThawAccount Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field Transfer Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field TransferChecked Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static final field UiAmountToAmount Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getIndex-w2LRezQ ()B
+	public static fun valueOf (Ljava/lang/String;)Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+	public static fun values ()[Lnet/avianlabs/solana/domain/program/TokenProgram$Instruction;
+}
+
+public final class net/avianlabs/solana/methods/AccountInfo {
+	public static final field Companion Lnet/avianlabs/solana/methods/AccountInfo$Companion;
+	public synthetic fun <init> (ZLjava/lang/String;JLjava/util/List;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-s-VKNKU ()J
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5-s-VKNKU ()J
+	public final fun copy-v3Jjnik (ZLjava/lang/String;JLjava/util/List;J)Lnet/avianlabs/solana/methods/AccountInfo;
+	public static synthetic fun copy-v3Jjnik$default (Lnet/avianlabs/solana/methods/AccountInfo;ZLjava/lang/String;JLjava/util/List;JILjava/lang/Object;)Lnet/avianlabs/solana/methods/AccountInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/util/List;
+	public final fun getDataBytes ()[B
+	public final fun getExecutable ()Z
+	public final fun getLamports-s-VKNKU ()J
+	public final fun getOwner ()Ljava/lang/String;
+	public final fun getOwnerPublicKey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getRentEpoch-s-VKNKU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/AccountInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/AccountInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/AccountInfo;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/AccountInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/AccountInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/GetAccountInfoKt {
+	public static final fun getAccountInfo (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getAccountInfo$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetBalanceKt {
+	public static final fun getBalance (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getBalance$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetFeeForMessageKt {
+	public static final fun getFeeForMessage (Lnet/avianlabs/solana/SolanaClient;[BLnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getFeeForMessage$default (Lnet/avianlabs/solana/SolanaClient;[BLnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetLatestBlockhashKt {
+	public static final fun getLatestBlockhash (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getLatestBlockhash$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetMinimumBalanceForRentExemptionKt {
+	public static final fun getMinimumBalanceForRentExemption (Lnet/avianlabs/solana/SolanaClient;JLnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getMinimumBalanceForRentExemption$default (Lnet/avianlabs/solana/SolanaClient;JLnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetNonceKt {
+	public static final fun getNonce (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getNonce$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetRecentBlockhashKt {
+	public static final fun getRecentBlockhash (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRecentBlockhash$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetSignaturesForAddressKt {
+	public static final fun getSignaturesForAddress (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getSignaturesForAddress$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetTokenAccountBalanceKt {
+	public static final fun getTokenAccountBalance (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getTokenAccountBalance$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Lnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/GetTransactionKt {
+	public static final fun getTransaction (Lnet/avianlabs/solana/SolanaClient;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getTransaction$default (Lnet/avianlabs/solana/SolanaClient;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/IsBlockHashValidKt {
+	public static final fun isBlockHashValid (Lnet/avianlabs/solana/SolanaClient;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun isBlockHashValid$default (Lnet/avianlabs/solana/SolanaClient;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/LatestBlockHash {
+	public static final field Companion Lnet/avianlabs/solana/methods/LatestBlockHash$Companion;
+	public fun <init> (Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun copy (Ljava/lang/String;J)Lnet/avianlabs/solana/methods/LatestBlockHash;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/LatestBlockHash;Ljava/lang/String;JILjava/lang/Object;)Lnet/avianlabs/solana/methods/LatestBlockHash;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockhash ()Ljava/lang/String;
+	public final fun getLastValidBlockHeight ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/LatestBlockHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/LatestBlockHash$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/LatestBlockHash;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/LatestBlockHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/LatestBlockHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/NonceAccount {
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;)Lnet/avianlabs/solana/methods/NonceAccount;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/NonceAccount;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/NonceAccount;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthorizedPubkey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getFeeCalculator ()Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public final fun getNonce ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/methods/RecentBlockHash {
+	public static final field Companion Lnet/avianlabs/solana/methods/RecentBlockHash$Companion;
+	public fun <init> (Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public final fun copy (Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;)Lnet/avianlabs/solana/methods/RecentBlockHash;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/RecentBlockHash;Ljava/lang/String;Lnet/avianlabs/solana/domain/core/FeeCalculator;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/RecentBlockHash;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockhash ()Ljava/lang/String;
+	public final fun getFeeCalculator ()Lnet/avianlabs/solana/domain/core/FeeCalculator;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/RecentBlockHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/RecentBlockHash$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/RecentBlockHash;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/RecentBlockHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/RecentBlockHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/RequestAirdropKt {
+	public static final fun requestAirdrop (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun requestAirdrop$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;JLnet/avianlabs/solana/domain/core/Commitment;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/SendTransactionKt {
+	public static final fun sendTransaction (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/SignedTransaction;ZLnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Integer;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun sendTransaction (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/VersionedTransaction;ZLnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Integer;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun sendTransaction$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/SignedTransaction;ZLnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Integer;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun sendTransaction$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/VersionedTransaction;ZLnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Integer;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/SignatureInformation {
+	public static final field Companion Lnet/avianlabs/solana/methods/SignatureInformation$Companion;
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;)Lnet/avianlabs/solana/methods/SignatureInformation;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/SignatureInformation;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/SignatureInformation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockTime ()Ljava/lang/Long;
+	public final fun getConfirmationStatus ()Ljava/lang/String;
+	public final fun getErr ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getMemo ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getSignature ()Ljava/lang/String;
+	public final fun getSlot ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public final fun setErr (Lkotlinx/serialization/json/JsonElement;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/SignatureInformation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/SignatureInformation$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/SignatureInformation;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/SignatureInformation;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/SignatureInformation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/SimulateTransactionKt {
+	public static final fun simulateTransaction-3rIlxjM (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/SignedTransaction;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/ULong;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun simulateTransaction-3rIlxjM (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/VersionedTransaction;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/ULong;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun simulateTransaction-3rIlxjM$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/SignedTransaction;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/ULong;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun simulateTransaction-3rIlxjM$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/VersionedTransaction;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/ULong;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun simulateTransaction-vepwEFk (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/Transaction;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/ULong;Ljava/lang/Boolean;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun simulateTransaction-vepwEFk$default (Lnet/avianlabs/solana/SolanaClient;Lnet/avianlabs/solana/domain/core/Transaction;Lnet/avianlabs/solana/domain/core/Commitment;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/ULong;Ljava/lang/Boolean;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class net/avianlabs/solana/methods/SimulateTransactionResponse {
+	public static final field Companion Lnet/avianlabs/solana/methods/SimulateTransactionResponse$Companion;
+	public synthetic fun <init> (Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Ljava/util/List;JLnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4-s-VKNKU ()J
+	public final fun component5 ()Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-EC5Vqqo (Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Ljava/util/List;JLnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;Lkotlinx/serialization/json/JsonElement;)Lnet/avianlabs/solana/methods/SimulateTransactionResponse;
+	public static synthetic fun copy-EC5Vqqo$default (Lnet/avianlabs/solana/methods/SimulateTransactionResponse;Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Ljava/util/List;JLnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/SimulateTransactionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccounts ()Ljava/util/List;
+	public final fun getErr ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getInnerInstructions ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getLogs ()Ljava/util/List;
+	public final fun getReturnData ()Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;
+	public final fun getUnitsConsumed-s-VKNKU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/SimulateTransactionResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/SimulateTransactionResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/SimulateTransactionResponse;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/SimulateTransactionResponse;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo {
+	public static final field Companion Lnet/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo$Companion;
+	public synthetic fun <init> (JLjava/lang/String;Lkotlinx/serialization/json/JsonElement;ZJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-s-VKNKU ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component4 ()Z
+	public final fun component5-s-VKNKU ()J
+	public final fun copy-6LX_a7M (JLjava/lang/String;Lkotlinx/serialization/json/JsonElement;ZJ)Lnet/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo;
+	public static synthetic fun copy-6LX_a7M$default (Lnet/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo;JLjava/lang/String;Lkotlinx/serialization/json/JsonElement;ZJILjava/lang/Object;)Lnet/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getExecutable ()Z
+	public final fun getLamports-s-VKNKU ()J
+	public final fun getOwner ()Ljava/lang/String;
+	public final fun getRentEpoch-s-VKNKU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/SimulateTransactionResponse$AccountInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/SimulateTransactionResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData {
+	public static final field Companion Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public final fun getProgramId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/SimulateTransactionResponse$ReturnData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TokenAmountInfo {
+	public static final field Companion Lnet/avianlabs/solana/methods/TokenAmountInfo$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/Double;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ILjava/lang/Double;Ljava/lang/String;)Lnet/avianlabs/solana/methods/TokenAmountInfo;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TokenAmountInfo;Ljava/lang/String;ILjava/lang/Double;Ljava/lang/String;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TokenAmountInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmount ()Ljava/lang/String;
+	public final fun getDecimals ()I
+	public final fun getUiAmount ()Ljava/lang/Double;
+	public final fun getUiAmountString ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TokenAmountInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TokenAmountInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TokenAmountInfo;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TokenAmountInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TokenAmountInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$Companion;
+	public fun <init> (Lnet/avianlabs/solana/methods/TransactionResponse$Meta;Ljava/lang/Long;Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;Ljava/lang/Long;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lnet/avianlabs/solana/methods/TransactionResponse$Meta;Ljava/lang/Long;Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;Ljava/lang/Long;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lnet/avianlabs/solana/methods/TransactionResponse$Meta;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lnet/avianlabs/solana/methods/TransactionResponse$Meta;Ljava/lang/Long;Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;Ljava/lang/Long;Lkotlinx/serialization/json/JsonElement;)Lnet/avianlabs/solana/methods/TransactionResponse;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse;Lnet/avianlabs/solana/methods/TransactionResponse$Meta;Ljava/lang/Long;Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;Ljava/lang/Long;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockTime ()Ljava/lang/Long;
+	public final fun getMeta ()Lnet/avianlabs/solana/methods/TransactionResponse$Meta;
+	public final fun getSlot ()Ljava/lang/Long;
+	public final fun getTransaction ()Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;
+	public final fun getVersion ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$AddressTableLookup {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$AddressTableLookup$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lnet/avianlabs/solana/methods/TransactionResponse$AddressTableLookup;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$AddressTableLookup;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$AddressTableLookup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountKey ()Ljava/lang/String;
+	public final fun getReadonlyIndexes ()Ljava/util/List;
+	public final fun getWritableIndexes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$AddressTableLookup$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$AddressTableLookup$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$AddressTableLookup;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$AddressTableLookup;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$AddressTableLookup$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Header {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$Header$Companion;
+	public fun <init> (JJJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun copy (JJJ)Lnet/avianlabs/solana/methods/TransactionResponse$Header;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$Header;JJJILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$Header;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNumReadonlySignedAccounts ()J
+	public final fun getNumReadonlyUnsignedAccounts ()J
+	public final fun getNumRequiredSignatures ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$Header$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$Header$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$Header;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$Header;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Header$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Instruction {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$Instruction$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun copy (Ljava/util/List;Ljava/lang/String;J)Lnet/avianlabs/solana/methods/TransactionResponse$Instruction;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$Instruction;Ljava/util/List;Ljava/lang/String;JILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$Instruction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccounts ()Ljava/util/List;
+	public final fun getData ()Ljava/lang/String;
+	public final fun getProgramIdIndex ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$Instruction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$Instruction$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$Instruction;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$Instruction;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Instruction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$LoadedAddresses {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReadonly ()Ljava/util/List;
+	public final fun getWritable ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$LoadedAddresses$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$LoadedAddresses$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Message {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$Message$Companion;
+	public fun <init> (Ljava/util/List;Lnet/avianlabs/solana/methods/TransactionResponse$Header;Ljava/util/List;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Lnet/avianlabs/solana/methods/TransactionResponse$Header;Ljava/util/List;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lnet/avianlabs/solana/methods/TransactionResponse$Header;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Lnet/avianlabs/solana/methods/TransactionResponse$Header;Ljava/util/List;Ljava/lang/String;Ljava/util/List;)Lnet/avianlabs/solana/methods/TransactionResponse$Message;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$Message;Ljava/util/List;Lnet/avianlabs/solana/methods/TransactionResponse$Header;Ljava/util/List;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$Message;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountKeys ()Ljava/util/List;
+	public final fun getAddressTableLookups ()Ljava/util/List;
+	public final fun getHeader ()Lnet/avianlabs/solana/methods/TransactionResponse$Header;
+	public final fun getInstructions ()Ljava/util/List;
+	public final fun getRecentBlockhash ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$Message$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$Message$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$Message;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$Message;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Message$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Meta {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$Meta$Companion;
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;JLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/JsonElement;JLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;JLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;)Lnet/avianlabs/solana/methods/TransactionResponse$Meta;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$Meta;Lkotlinx/serialization/json/JsonElement;JLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$Meta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErr ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getFee ()J
+	public final fun getInnerInstructions ()Ljava/util/List;
+	public final fun getLoadedAddresses ()Lnet/avianlabs/solana/methods/TransactionResponse$LoadedAddresses;
+	public final fun getLogMessages ()Ljava/util/List;
+	public final fun getPostBalances ()Ljava/util/List;
+	public final fun getPostTokenBalances ()Ljava/util/List;
+	public final fun getPreBalances ()Ljava/util/List;
+	public final fun getPreTokenBalances ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$Meta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$Meta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$Meta;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$Meta;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Meta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta$Companion;
+	public fun <init> (JLjava/util/List;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (JLjava/util/List;)Lnet/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta;JLjava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()J
+	public final fun getInstructions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Meta$InnerInstructionMeta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$TokenBalance {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$TokenBalance$Companion;
+	public fun <init> (JLjava/lang/String;Lnet/avianlabs/solana/methods/TokenAmountInfo;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lnet/avianlabs/solana/methods/TokenAmountInfo;
+	public final fun copy (JLjava/lang/String;Lnet/avianlabs/solana/methods/TokenAmountInfo;)Lnet/avianlabs/solana/methods/TransactionResponse$TokenBalance;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$TokenBalance;JLjava/lang/String;Lnet/avianlabs/solana/methods/TokenAmountInfo;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$TokenBalance;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountIndex ()J
+	public final fun getMint ()Ljava/lang/String;
+	public final fun getUiTokenAmount ()Lnet/avianlabs/solana/methods/TokenAmountInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$TokenBalance$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$TokenBalance$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$TokenBalance;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$TokenBalance;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$TokenBalance$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Transaction {
+	public static final field Companion Lnet/avianlabs/solana/methods/TransactionResponse$Transaction$Companion;
+	public fun <init> (Lnet/avianlabs/solana/methods/TransactionResponse$Message;Ljava/util/List;)V
+	public final fun component1 ()Lnet/avianlabs/solana/methods/TransactionResponse$Message;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lnet/avianlabs/solana/methods/TransactionResponse$Message;Ljava/util/List;)Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;Lnet/avianlabs/solana/methods/TransactionResponse$Message;Ljava/util/List;ILjava/lang/Object;)Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lnet/avianlabs/solana/methods/TransactionResponse$Message;
+	public final fun getSignatures ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/avianlabs/solana/methods/TransactionResponse$Transaction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/avianlabs/solana/methods/TransactionResponse$Transaction$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/avianlabs/solana/methods/TransactionResponse$Transaction;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/avianlabs/solana/methods/TransactionResponse$Transaction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/solana-kotlin/api/solana-kotlin.klib.api
+++ b/solana-kotlin/api/solana-kotlin.klib.api
@@ -1,0 +1,2638 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, linuxX64, mingwX64]
+// Alias: ios => [iosArm64, iosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <net.avianlabs.solana:solana-kotlin>
+final enum class net.avianlabs.solana.domain.core/Commitment : kotlin/Enum<net.avianlabs.solana.domain.core/Commitment> { // net.avianlabs.solana.domain.core/Commitment|null[0]
+    enum entry Confirmed // net.avianlabs.solana.domain.core/Commitment.Confirmed|null[0]
+    enum entry Finalized // net.avianlabs.solana.domain.core/Commitment.Finalized|null[0]
+    enum entry Processed // net.avianlabs.solana.domain.core/Commitment.Processed|null[0]
+
+    final val entries // net.avianlabs.solana.domain.core/Commitment.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.core/Commitment> // net.avianlabs.solana.domain.core/Commitment.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val value // net.avianlabs.solana.domain.core/Commitment.value|{}value[0]
+        final fun <get-value>(): kotlin/String // net.avianlabs.solana.domain.core/Commitment.value.<get-value>|<get-value>(){}[0]
+
+    final fun valueOf(kotlin/String): net.avianlabs.solana.domain.core/Commitment // net.avianlabs.solana.domain.core/Commitment.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<net.avianlabs.solana.domain.core/Commitment> // net.avianlabs.solana.domain.core/Commitment.values|values#static(){}[0]
+}
+
+abstract interface net.avianlabs.solana.client/RpcResult // net.avianlabs.solana.client/RpcResult|null[0]
+
+abstract interface net.avianlabs.solana.domain.program/Program { // net.avianlabs.solana.domain.program/Program|null[0]
+    abstract val programId // net.avianlabs.solana.domain.program/Program.programId|{}programId[0]
+        abstract fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Program.programId.<get-programId>|<get-programId>(){}[0]
+
+    final object Companion { // net.avianlabs.solana.domain.program/Program.Companion|null[0]
+        final fun findProgramAddress(kotlin.collections/List<kotlin/ByteArray>, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.program/ProgramDerivedAddress // net.avianlabs.solana.domain.program/Program.Companion.findProgramAddress|findProgramAddress(kotlin.collections.List<kotlin.ByteArray>;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    }
+}
+
+abstract class net.avianlabs.solana.client/ResultParserError : kotlin/Throwable { // net.avianlabs.solana.client/ResultParserError|null[0]
+    constructor <init>(kotlin/Throwable) // net.avianlabs.solana.client/ResultParserError.<init>|<init>(kotlin.Throwable){}[0]
+}
+
+final class <#A: kotlin/Any?> net.avianlabs.solana.client/Response { // net.avianlabs.solana.client/Response|null[0]
+    constructor <init>(kotlin/Int, kotlin/String, #A? = ..., net.avianlabs.solana.client/RpcError? = ...) // net.avianlabs.solana.client/Response.<init>|<init>(kotlin.Int;kotlin.String;1:0?;net.avianlabs.solana.client.RpcError?){}[0]
+
+    final val error // net.avianlabs.solana.client/Response.error|{}error[0]
+        final fun <get-error>(): net.avianlabs.solana.client/RpcError? // net.avianlabs.solana.client/Response.error.<get-error>|<get-error>(){}[0]
+    final val id // net.avianlabs.solana.client/Response.id|{}id[0]
+        final fun <get-id>(): kotlin/Int // net.avianlabs.solana.client/Response.id.<get-id>|<get-id>(){}[0]
+    final val jsonrpc // net.avianlabs.solana.client/Response.jsonrpc|{}jsonrpc[0]
+        final fun <get-jsonrpc>(): kotlin/String // net.avianlabs.solana.client/Response.jsonrpc.<get-jsonrpc>|<get-jsonrpc>(){}[0]
+    final val result // net.avianlabs.solana.client/Response.result|{}result[0]
+        final fun <get-result>(): #A? // net.avianlabs.solana.client/Response.result.<get-result>|<get-result>(){}[0]
+
+    final fun component1(): kotlin/Int // net.avianlabs.solana.client/Response.component1|component1(){}[0]
+    final fun component2(): kotlin/String // net.avianlabs.solana.client/Response.component2|component2(){}[0]
+    final fun component3(): #A? // net.avianlabs.solana.client/Response.component3|component3(){}[0]
+    final fun component4(): net.avianlabs.solana.client/RpcError? // net.avianlabs.solana.client/Response.component4|component4(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/String = ..., #A? = ..., net.avianlabs.solana.client/RpcError? = ...): net.avianlabs.solana.client/Response<#A> // net.avianlabs.solana.client/Response.copy|copy(kotlin.Int;kotlin.String;1:0?;net.avianlabs.solana.client.RpcError?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.client/Response.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.client/Response.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.client/Response.toString|toString(){}[0]
+
+    final class <#A1: kotlin/Any?> $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.client/Response<#A1>> { // net.avianlabs.solana.client/Response.$serializer|null[0]
+        constructor <init>(kotlinx.serialization/KSerializer<#A1>) // net.avianlabs.solana.client/Response.$serializer.<init>|<init>(kotlinx.serialization.KSerializer<1:0>){}[0]
+
+        final val descriptor // net.avianlabs.solana.client/Response.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.client/Response.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val typeSerial0 // net.avianlabs.solana.client/Response.$serializer.typeSerial0|{}typeSerial0[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.client/Response.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.client/Response<#A1> // net.avianlabs.solana.client/Response.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.client/Response<#A1>) // net.avianlabs.solana.client/Response.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.client.Response<1:0>){}[0]
+        final fun typeParametersSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.client/Response.$serializer.typeParametersSerializers|typeParametersSerializers(){}[0]
+    }
+
+    final class <#A1: kotlin/Any?> RPC { // net.avianlabs.solana.client/Response.RPC|null[0]
+        constructor <init>(net.avianlabs.solana.client/Response.RPC.Context, #A1) // net.avianlabs.solana.client/Response.RPC.<init>|<init>(net.avianlabs.solana.client.Response.RPC.Context;1:0){}[0]
+
+        final val context // net.avianlabs.solana.client/Response.RPC.context|{}context[0]
+            final fun <get-context>(): net.avianlabs.solana.client/Response.RPC.Context // net.avianlabs.solana.client/Response.RPC.context.<get-context>|<get-context>(){}[0]
+        final val value // net.avianlabs.solana.client/Response.RPC.value|{}value[0]
+            final fun <get-value>(): #A1 // net.avianlabs.solana.client/Response.RPC.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): net.avianlabs.solana.client/Response.RPC.Context // net.avianlabs.solana.client/Response.RPC.component1|component1(){}[0]
+        final fun component2(): #A1 // net.avianlabs.solana.client/Response.RPC.component2|component2(){}[0]
+        final fun copy(net.avianlabs.solana.client/Response.RPC.Context = ..., #A1 = ...): net.avianlabs.solana.client/Response.RPC<#A1> // net.avianlabs.solana.client/Response.RPC.copy|copy(net.avianlabs.solana.client.Response.RPC.Context;1:0){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.client/Response.RPC.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.client/Response.RPC.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.client/Response.RPC.toString|toString(){}[0]
+
+        final class <#A2: kotlin/Any?> $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.client/Response.RPC<#A2>> { // net.avianlabs.solana.client/Response.RPC.$serializer|null[0]
+            constructor <init>(kotlinx.serialization/KSerializer<#A2>) // net.avianlabs.solana.client/Response.RPC.$serializer.<init>|<init>(kotlinx.serialization.KSerializer<1:0>){}[0]
+
+            final val descriptor // net.avianlabs.solana.client/Response.RPC.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.client/Response.RPC.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+            final val typeSerial0 // net.avianlabs.solana.client/Response.RPC.$serializer.typeSerial0|{}typeSerial0[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.client/Response.RPC.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.client/Response.RPC<#A2> // net.avianlabs.solana.client/Response.RPC.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.client/Response.RPC<#A2>) // net.avianlabs.solana.client/Response.RPC.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.client.Response.RPC<1:0>){}[0]
+            final fun typeParametersSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.client/Response.RPC.$serializer.typeParametersSerializers|typeParametersSerializers(){}[0]
+        }
+
+        final class Context { // net.avianlabs.solana.client/Response.RPC.Context|null[0]
+            constructor <init>(kotlin/ULong, kotlin/String?) // net.avianlabs.solana.client/Response.RPC.Context.<init>|<init>(kotlin.ULong;kotlin.String?){}[0]
+
+            final val apiVersion // net.avianlabs.solana.client/Response.RPC.Context.apiVersion|{}apiVersion[0]
+                final fun <get-apiVersion>(): kotlin/String? // net.avianlabs.solana.client/Response.RPC.Context.apiVersion.<get-apiVersion>|<get-apiVersion>(){}[0]
+            final val slot // net.avianlabs.solana.client/Response.RPC.Context.slot|{}slot[0]
+                final fun <get-slot>(): kotlin/ULong // net.avianlabs.solana.client/Response.RPC.Context.slot.<get-slot>|<get-slot>(){}[0]
+
+            final fun component1(): kotlin/ULong // net.avianlabs.solana.client/Response.RPC.Context.component1|component1(){}[0]
+            final fun component2(): kotlin/String? // net.avianlabs.solana.client/Response.RPC.Context.component2|component2(){}[0]
+            final fun copy(kotlin/ULong = ..., kotlin/String? = ...): net.avianlabs.solana.client/Response.RPC.Context // net.avianlabs.solana.client/Response.RPC.Context.copy|copy(kotlin.ULong;kotlin.String?){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.client/Response.RPC.Context.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.client/Response.RPC.Context.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.client/Response.RPC.Context.toString|toString(){}[0]
+
+            final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.client/Response.RPC.Context> { // net.avianlabs.solana.client/Response.RPC.Context.$serializer|null[0]
+                final val descriptor // net.avianlabs.solana.client/Response.RPC.Context.$serializer.descriptor|{}descriptor[0]
+                    final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.client/Response.RPC.Context.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+                final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.client/Response.RPC.Context.$serializer.childSerializers|childSerializers(){}[0]
+                final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.client/Response.RPC.Context // net.avianlabs.solana.client/Response.RPC.Context.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+                final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.client/Response.RPC.Context) // net.avianlabs.solana.client/Response.RPC.Context.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.client.Response.RPC.Context){}[0]
+            }
+
+            final object Companion { // net.avianlabs.solana.client/Response.RPC.Context.Companion|null[0]
+                final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.client/Response.RPC.Context> // net.avianlabs.solana.client/Response.RPC.Context.Companion.serializer|serializer(){}[0]
+            }
+        }
+
+        final object Companion : kotlinx.serialization.internal/SerializerFactory { // net.avianlabs.solana.client/Response.RPC.Companion|null[0]
+            final val $cachedDescriptor // net.avianlabs.solana.client/Response.RPC.Companion.$cachedDescriptor|{}$cachedDescriptor[0]
+                final fun <get-$cachedDescriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.client/Response.RPC.Companion.$cachedDescriptor.<get-$cachedDescriptor>|<get-$cachedDescriptor>(){}[0]
+
+            final fun <#A3: kotlin/Any?> serializer(kotlinx.serialization/KSerializer<#A3>): kotlinx.serialization/KSerializer<net.avianlabs.solana.client/Response.RPC<#A3>> // net.avianlabs.solana.client/Response.RPC.Companion.serializer|serializer(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
+            final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // net.avianlabs.solana.client/Response.RPC.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+        }
+    }
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // net.avianlabs.solana.client/Response.Companion|null[0]
+        final val $cachedDescriptor // net.avianlabs.solana.client/Response.Companion.$cachedDescriptor|{}$cachedDescriptor[0]
+            final fun <get-$cachedDescriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.client/Response.Companion.$cachedDescriptor.<get-$cachedDescriptor>|<get-$cachedDescriptor>(){}[0]
+
+        final fun <#A2: kotlin/Any?> serializer(kotlinx.serialization/KSerializer<#A2>): kotlinx.serialization/KSerializer<net.avianlabs.solana.client/Response<#A2>> // net.avianlabs.solana.client/Response.Companion.serializer|serializer(kotlinx.serialization.KSerializer<0:0>){0§<kotlin.Any?>}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // net.avianlabs.solana.client/Response.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
+final class <#A: kotlin/Any?> net.avianlabs.solana.client/RpcInvocation { // net.avianlabs.solana.client/RpcInvocation|null[0]
+    constructor <init>(kotlin/String, #A?, kotlin.collections/Map<kotlin/String, kotlin.coroutines/SuspendFunction0<kotlin/String?>>) // net.avianlabs.solana.client/RpcInvocation.<init>|<init>(kotlin.String;1:0?;kotlin.collections.Map<kotlin.String,kotlin.coroutines.SuspendFunction0<kotlin.String?>>){}[0]
+
+    final val headerProviders // net.avianlabs.solana.client/RpcInvocation.headerProviders|{}headerProviders[0]
+        final fun <get-headerProviders>(): kotlin.collections/Map<kotlin/String, kotlin.coroutines/SuspendFunction0<kotlin/String?>> // net.avianlabs.solana.client/RpcInvocation.headerProviders.<get-headerProviders>|<get-headerProviders>(){}[0]
+    final val method // net.avianlabs.solana.client/RpcInvocation.method|{}method[0]
+        final fun <get-method>(): kotlin/String // net.avianlabs.solana.client/RpcInvocation.method.<get-method>|<get-method>(){}[0]
+    final val params // net.avianlabs.solana.client/RpcInvocation.params|{}params[0]
+        final fun <get-params>(): #A? // net.avianlabs.solana.client/RpcInvocation.params.<get-params>|<get-params>(){}[0]
+
+    final fun component1(): kotlin/String // net.avianlabs.solana.client/RpcInvocation.component1|component1(){}[0]
+    final fun component2(): #A? // net.avianlabs.solana.client/RpcInvocation.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/String, kotlin.coroutines/SuspendFunction0<kotlin/String?>> // net.avianlabs.solana.client/RpcInvocation.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., #A? = ..., kotlin.collections/Map<kotlin/String, kotlin.coroutines/SuspendFunction0<kotlin/String?>> = ...): net.avianlabs.solana.client/RpcInvocation<#A> // net.avianlabs.solana.client/RpcInvocation.copy|copy(kotlin.String;1:0?;kotlin.collections.Map<kotlin.String,kotlin.coroutines.SuspendFunction0<kotlin.String?>>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.client/RpcInvocation.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.client/RpcInvocation.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.client/RpcInvocation.toString|toString(){}[0]
+}
+
+final class <#A: kotlin/Any?> net.avianlabs.solana.client/RpcRequest { // net.avianlabs.solana.client/RpcRequest|null[0]
+    constructor <init>(kotlin/Int? = ..., net.avianlabs.solana.client/RpcInvocation<#A>) // net.avianlabs.solana.client/RpcRequest.<init>|<init>(kotlin.Int?;net.avianlabs.solana.client.RpcInvocation<1:0>){}[0]
+
+    final val id // net.avianlabs.solana.client/RpcRequest.id|{}id[0]
+        final fun <get-id>(): kotlin/Int? // net.avianlabs.solana.client/RpcRequest.id.<get-id>|<get-id>(){}[0]
+    final val invocation // net.avianlabs.solana.client/RpcRequest.invocation|{}invocation[0]
+        final fun <get-invocation>(): net.avianlabs.solana.client/RpcInvocation<#A> // net.avianlabs.solana.client/RpcRequest.invocation.<get-invocation>|<get-invocation>(){}[0]
+
+    final fun component1(): kotlin/Int? // net.avianlabs.solana.client/RpcRequest.component1|component1(){}[0]
+    final fun component2(): net.avianlabs.solana.client/RpcInvocation<#A> // net.avianlabs.solana.client/RpcRequest.component2|component2(){}[0]
+    final fun copy(kotlin/Int? = ..., net.avianlabs.solana.client/RpcInvocation<#A> = ...): net.avianlabs.solana.client/RpcRequest<#A> // net.avianlabs.solana.client/RpcRequest.copy|copy(kotlin.Int?;net.avianlabs.solana.client.RpcInvocation<1:0>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.client/RpcRequest.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.client/RpcRequest.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.client/RpcRequest.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.client/HttpRequestExecutorConfig { // net.avianlabs.solana.client/HttpRequestExecutorConfig|null[0]
+    constructor <init>(io.ktor.http/Url) // net.avianlabs.solana.client/HttpRequestExecutorConfig.<init>|<init>(io.ktor.http.Url){}[0]
+
+    final val baseURL // net.avianlabs.solana.client/HttpRequestExecutorConfig.baseURL|{}baseURL[0]
+        final fun <get-baseURL>(): io.ktor.http/Url // net.avianlabs.solana.client/HttpRequestExecutorConfig.baseURL.<get-baseURL>|<get-baseURL>(){}[0]
+
+    final fun component1(): io.ktor.http/Url // net.avianlabs.solana.client/HttpRequestExecutorConfig.component1|component1(){}[0]
+    final fun copy(io.ktor.http/Url = ...): net.avianlabs.solana.client/HttpRequestExecutorConfig // net.avianlabs.solana.client/HttpRequestExecutorConfig.copy|copy(io.ktor.http.Url){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.client/HttpRequestExecutorConfig.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.client/HttpRequestExecutorConfig.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.client/HttpRequestExecutorConfig.toString|toString(){}[0]
+
+    final object Companion { // net.avianlabs.solana.client/HttpRequestExecutorConfig.Companion|null[0]
+        final const val version // net.avianlabs.solana.client/HttpRequestExecutorConfig.Companion.version|{}version[0]
+            final fun <get-version>(): kotlin/String // net.avianlabs.solana.client/HttpRequestExecutorConfig.Companion.version.<get-version>|<get-version>(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.client/RequestIdGenerator { // net.avianlabs.solana.client/RequestIdGenerator|null[0]
+    constructor <init>() // net.avianlabs.solana.client/RequestIdGenerator.<init>|<init>(){}[0]
+
+    final fun next(): kotlin/Int // net.avianlabs.solana.client/RequestIdGenerator.next|next(){}[0]
+}
+
+final class net.avianlabs.solana.client/RpcError { // net.avianlabs.solana.client/RpcError|null[0]
+    constructor <init>(kotlin/String, kotlin/Int, kotlinx.serialization.json/JsonObject? = ...) // net.avianlabs.solana.client/RpcError.<init>|<init>(kotlin.String;kotlin.Int;kotlinx.serialization.json.JsonObject?){}[0]
+
+    final val code // net.avianlabs.solana.client/RpcError.code|{}code[0]
+        final fun <get-code>(): kotlin/Int // net.avianlabs.solana.client/RpcError.code.<get-code>|<get-code>(){}[0]
+    final val data // net.avianlabs.solana.client/RpcError.data|{}data[0]
+        final fun <get-data>(): kotlinx.serialization.json/JsonObject? // net.avianlabs.solana.client/RpcError.data.<get-data>|<get-data>(){}[0]
+    final val message // net.avianlabs.solana.client/RpcError.message|{}message[0]
+        final fun <get-message>(): kotlin/String // net.avianlabs.solana.client/RpcError.message.<get-message>|<get-message>(){}[0]
+
+    final fun component1(): kotlin/String // net.avianlabs.solana.client/RpcError.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // net.avianlabs.solana.client/RpcError.component2|component2(){}[0]
+    final fun component3(): kotlinx.serialization.json/JsonObject? // net.avianlabs.solana.client/RpcError.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ..., kotlinx.serialization.json/JsonObject? = ...): net.avianlabs.solana.client/RpcError // net.avianlabs.solana.client/RpcError.copy|copy(kotlin.String;kotlin.Int;kotlinx.serialization.json.JsonObject?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.client/RpcError.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.client/RpcError.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.client/RpcError.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.client/RpcError> { // net.avianlabs.solana.client/RpcError.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.client/RpcError.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.client/RpcError.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.client/RpcError.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.client/RpcError // net.avianlabs.solana.client/RpcError.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.client/RpcError) // net.avianlabs.solana.client/RpcError.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.client.RpcError){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.client/RpcError.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.client/RpcError> // net.avianlabs.solana.client/RpcError.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.client/RpcKtorClient { // net.avianlabs.solana.client/RpcKtorClient|null[0]
+    constructor <init>(io.ktor.http/Url, io.ktor.client/HttpClient = ...) // net.avianlabs.solana.client/RpcKtorClient.<init>|<init>(io.ktor.http.Url;io.ktor.client.HttpClient){}[0]
+    constructor <init>(kotlin/String, io.ktor.client/HttpClient = ...) // net.avianlabs.solana.client/RpcKtorClient.<init>|<init>(kotlin.String;io.ktor.client.HttpClient){}[0]
+}
+
+final class net.avianlabs.solana.domain.core/AccountMeta { // net.avianlabs.solana.domain.core/AccountMeta|null[0]
+    constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Boolean, kotlin/Boolean) // net.avianlabs.solana.domain.core/AccountMeta.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Boolean;kotlin.Boolean){}[0]
+
+    final val isSigner // net.avianlabs.solana.domain.core/AccountMeta.isSigner|{}isSigner[0]
+        final fun <get-isSigner>(): kotlin/Boolean // net.avianlabs.solana.domain.core/AccountMeta.isSigner.<get-isSigner>|<get-isSigner>(){}[0]
+    final val isWritable // net.avianlabs.solana.domain.core/AccountMeta.isWritable|{}isWritable[0]
+        final fun <get-isWritable>(): kotlin/Boolean // net.avianlabs.solana.domain.core/AccountMeta.isWritable.<get-isWritable>|<get-isWritable>(){}[0]
+    final val publicKey // net.avianlabs.solana.domain.core/AccountMeta.publicKey|{}publicKey[0]
+        final fun <get-publicKey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/AccountMeta.publicKey.<get-publicKey>|<get-publicKey>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/AccountMeta.component1|component1(){}[0]
+    final fun component2(): kotlin/Boolean // net.avianlabs.solana.domain.core/AccountMeta.component2|component2(){}[0]
+    final fun component3(): kotlin/Boolean // net.avianlabs.solana.domain.core/AccountMeta.component3|component3(){}[0]
+    final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/Boolean = ..., kotlin/Boolean = ...): net.avianlabs.solana.domain.core/AccountMeta // net.avianlabs.solana.domain.core/AccountMeta.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Boolean;kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/AccountMeta.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/AccountMeta.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/AccountMeta.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.domain.core/AddressLookupTableAccount { // net.avianlabs.solana.domain.core/AddressLookupTableAccount|null[0]
+    constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey>) // net.avianlabs.solana.domain.core/AddressLookupTableAccount.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.PublicKey>){}[0]
+
+    final val addresses // net.avianlabs.solana.domain.core/AddressLookupTableAccount.addresses|{}addresses[0]
+        final fun <get-addresses>(): kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey> // net.avianlabs.solana.domain.core/AddressLookupTableAccount.addresses.<get-addresses>|<get-addresses>(){}[0]
+    final val key // net.avianlabs.solana.domain.core/AddressLookupTableAccount.key|{}key[0]
+        final fun <get-key>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/AddressLookupTableAccount.key.<get-key>|<get-key>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/AddressLookupTableAccount.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey> // net.avianlabs.solana.domain.core/AddressLookupTableAccount.component2|component2(){}[0]
+    final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey> = ...): net.avianlabs.solana.domain.core/AddressLookupTableAccount // net.avianlabs.solana.domain.core/AddressLookupTableAccount.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.PublicKey>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/AddressLookupTableAccount.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/AddressLookupTableAccount.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/AddressLookupTableAccount.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.domain.core/DecodedTransaction { // net.avianlabs.solana.domain.core/DecodedTransaction|null[0]
+    constructor <init>(kotlin.collections/List<net.avianlabs.solana.domain.core/DecodedInstruction>, kotlin.collections/List<net.avianlabs.solana.domain.core/SignaturePublicKeyPair>) // net.avianlabs.solana.domain.core/DecodedTransaction.<init>|<init>(kotlin.collections.List<net.avianlabs.solana.domain.core.DecodedInstruction>;kotlin.collections.List<net.avianlabs.solana.domain.core.SignaturePublicKeyPair>){}[0]
+
+    final val instructions // net.avianlabs.solana.domain.core/DecodedTransaction.instructions|{}instructions[0]
+        final fun <get-instructions>(): kotlin.collections/List<net.avianlabs.solana.domain.core/DecodedInstruction> // net.avianlabs.solana.domain.core/DecodedTransaction.instructions.<get-instructions>|<get-instructions>(){}[0]
+    final val signatures // net.avianlabs.solana.domain.core/DecodedTransaction.signatures|{}signatures[0]
+        final fun <get-signatures>(): kotlin.collections/List<net.avianlabs.solana.domain.core/SignaturePublicKeyPair> // net.avianlabs.solana.domain.core/DecodedTransaction.signatures.<get-signatures>|<get-signatures>(){}[0]
+
+    final fun component1(): kotlin.collections/List<net.avianlabs.solana.domain.core/DecodedInstruction> // net.avianlabs.solana.domain.core/DecodedTransaction.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<net.avianlabs.solana.domain.core/SignaturePublicKeyPair> // net.avianlabs.solana.domain.core/DecodedTransaction.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<net.avianlabs.solana.domain.core/DecodedInstruction> = ..., kotlin.collections/List<net.avianlabs.solana.domain.core/SignaturePublicKeyPair> = ...): net.avianlabs.solana.domain.core/DecodedTransaction // net.avianlabs.solana.domain.core/DecodedTransaction.copy|copy(kotlin.collections.List<net.avianlabs.solana.domain.core.DecodedInstruction>;kotlin.collections.List<net.avianlabs.solana.domain.core.SignaturePublicKeyPair>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedTransaction.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedTransaction.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedTransaction.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.domain.core/FeeCalculator { // net.avianlabs.solana.domain.core/FeeCalculator|null[0]
+    constructor <init>(kotlin/ULong) // net.avianlabs.solana.domain.core/FeeCalculator.<init>|<init>(kotlin.ULong){}[0]
+
+    final val lamportsPerSignature // net.avianlabs.solana.domain.core/FeeCalculator.lamportsPerSignature|{}lamportsPerSignature[0]
+        final fun <get-lamportsPerSignature>(): kotlin/ULong // net.avianlabs.solana.domain.core/FeeCalculator.lamportsPerSignature.<get-lamportsPerSignature>|<get-lamportsPerSignature>(){}[0]
+
+    final fun component1(): kotlin/ULong // net.avianlabs.solana.domain.core/FeeCalculator.component1|component1(){}[0]
+    final fun copy(kotlin/ULong = ...): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.domain.core/FeeCalculator.copy|copy(kotlin.ULong){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/FeeCalculator.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/FeeCalculator.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/FeeCalculator.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.domain.core/FeeCalculator> { // net.avianlabs.solana.domain.core/FeeCalculator.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.domain.core/FeeCalculator.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.domain.core/FeeCalculator.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.domain.core/FeeCalculator.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.domain.core/FeeCalculator.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.domain.core/FeeCalculator) // net.avianlabs.solana.domain.core/FeeCalculator.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.domain.core.FeeCalculator){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.domain.core/FeeCalculator.Companion|null[0]
+        final fun read(okio/BufferedSource): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.domain.core/FeeCalculator.Companion.read|read(okio.BufferedSource){}[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.domain.core/FeeCalculator> // net.avianlabs.solana.domain.core/FeeCalculator.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.domain.core/Message { // net.avianlabs.solana.domain.core/Message|null[0]
+    final val accountKeys // net.avianlabs.solana.domain.core/Message.accountKeys|{}accountKeys[0]
+        final fun <get-accountKeys>(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> // net.avianlabs.solana.domain.core/Message.accountKeys.<get-accountKeys>|<get-accountKeys>(){}[0]
+    final val feePayer // net.avianlabs.solana.domain.core/Message.feePayer|{}feePayer[0]
+        final fun <get-feePayer>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.core/Message.feePayer.<get-feePayer>|<get-feePayer>(){}[0]
+    final val instructions // net.avianlabs.solana.domain.core/Message.instructions|{}instructions[0]
+        final fun <get-instructions>(): kotlin.collections/List<net.avianlabs.solana.domain.core/TransactionInstruction> // net.avianlabs.solana.domain.core/Message.instructions.<get-instructions>|<get-instructions>(){}[0]
+    final val recentBlockHash // net.avianlabs.solana.domain.core/Message.recentBlockHash|{}recentBlockHash[0]
+        final fun <get-recentBlockHash>(): kotlin/String? // net.avianlabs.solana.domain.core/Message.recentBlockHash.<get-recentBlockHash>|<get-recentBlockHash>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.core/Message.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // net.avianlabs.solana.domain.core/Message.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> // net.avianlabs.solana.domain.core/Message.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<net.avianlabs.solana.domain.core/TransactionInstruction> // net.avianlabs.solana.domain.core/Message.component4|component4(){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/Message.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/Message.hashCode|hashCode(){}[0]
+    final fun newBuilder(): net.avianlabs.solana.domain.core/Message.Builder // net.avianlabs.solana.domain.core/Message.newBuilder|newBuilder(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/Message.toString|toString(){}[0]
+
+    final class Builder { // net.avianlabs.solana.domain.core/Message.Builder|null[0]
+        constructor <init>() // net.avianlabs.solana.domain.core/Message.Builder.<init>|<init>(){}[0]
+
+        final fun addInstruction(net.avianlabs.solana.domain.core/TransactionInstruction): net.avianlabs.solana.domain.core/Message.Builder // net.avianlabs.solana.domain.core/Message.Builder.addInstruction|addInstruction(net.avianlabs.solana.domain.core.TransactionInstruction){}[0]
+        final fun build(): net.avianlabs.solana.domain.core/Message // net.avianlabs.solana.domain.core/Message.Builder.build|build(){}[0]
+        final fun setFeePayer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/Message.Builder // net.avianlabs.solana.domain.core/Message.Builder.setFeePayer|setFeePayer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun setRecentBlockHash(kotlin/String): net.avianlabs.solana.domain.core/Message.Builder // net.avianlabs.solana.domain.core/Message.Builder.setRecentBlockHash|setRecentBlockHash(kotlin.String){}[0]
+    }
+}
+
+final class net.avianlabs.solana.domain.core/MessageAddressTableLookup { // net.avianlabs.solana.domain.core/MessageAddressTableLookup|null[0]
+    constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin.collections/List<kotlin/UByte>, kotlin.collections/List<kotlin/UByte>) // net.avianlabs.solana.domain.core/MessageAddressTableLookup.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<kotlin.UByte>;kotlin.collections.List<kotlin.UByte>){}[0]
+
+    final val accountKey // net.avianlabs.solana.domain.core/MessageAddressTableLookup.accountKey|{}accountKey[0]
+        final fun <get-accountKey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/MessageAddressTableLookup.accountKey.<get-accountKey>|<get-accountKey>(){}[0]
+    final val readonlyIndexes // net.avianlabs.solana.domain.core/MessageAddressTableLookup.readonlyIndexes|{}readonlyIndexes[0]
+        final fun <get-readonlyIndexes>(): kotlin.collections/List<kotlin/UByte> // net.avianlabs.solana.domain.core/MessageAddressTableLookup.readonlyIndexes.<get-readonlyIndexes>|<get-readonlyIndexes>(){}[0]
+    final val writableIndexes // net.avianlabs.solana.domain.core/MessageAddressTableLookup.writableIndexes|{}writableIndexes[0]
+        final fun <get-writableIndexes>(): kotlin.collections/List<kotlin/UByte> // net.avianlabs.solana.domain.core/MessageAddressTableLookup.writableIndexes.<get-writableIndexes>|<get-writableIndexes>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/MessageAddressTableLookup.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<kotlin/UByte> // net.avianlabs.solana.domain.core/MessageAddressTableLookup.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<kotlin/UByte> // net.avianlabs.solana.domain.core/MessageAddressTableLookup.component3|component3(){}[0]
+    final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin.collections/List<kotlin/UByte> = ..., kotlin.collections/List<kotlin/UByte> = ...): net.avianlabs.solana.domain.core/MessageAddressTableLookup // net.avianlabs.solana.domain.core/MessageAddressTableLookup.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<kotlin.UByte>;kotlin.collections.List<kotlin.UByte>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/MessageAddressTableLookup.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/MessageAddressTableLookup.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/MessageAddressTableLookup.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.domain.core/NonceAccountData { // net.avianlabs.solana.domain.core/NonceAccountData|null[0]
+    constructor <init>(kotlin/UInt, kotlin/UInt, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String, net.avianlabs.solana.domain.core/FeeCalculator) // net.avianlabs.solana.domain.core/NonceAccountData.<init>|<init>(kotlin.UInt;kotlin.UInt;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;net.avianlabs.solana.domain.core.FeeCalculator){}[0]
+
+    final val authorizedPubkey // net.avianlabs.solana.domain.core/NonceAccountData.authorizedPubkey|{}authorizedPubkey[0]
+        final fun <get-authorizedPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/NonceAccountData.authorizedPubkey.<get-authorizedPubkey>|<get-authorizedPubkey>(){}[0]
+    final val feeCalculator // net.avianlabs.solana.domain.core/NonceAccountData.feeCalculator|{}feeCalculator[0]
+        final fun <get-feeCalculator>(): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.domain.core/NonceAccountData.feeCalculator.<get-feeCalculator>|<get-feeCalculator>(){}[0]
+    final val nonce // net.avianlabs.solana.domain.core/NonceAccountData.nonce|{}nonce[0]
+        final fun <get-nonce>(): kotlin/String // net.avianlabs.solana.domain.core/NonceAccountData.nonce.<get-nonce>|<get-nonce>(){}[0]
+    final val state // net.avianlabs.solana.domain.core/NonceAccountData.state|{}state[0]
+        final fun <get-state>(): kotlin/UInt // net.avianlabs.solana.domain.core/NonceAccountData.state.<get-state>|<get-state>(){}[0]
+    final val version // net.avianlabs.solana.domain.core/NonceAccountData.version|{}version[0]
+        final fun <get-version>(): kotlin/UInt // net.avianlabs.solana.domain.core/NonceAccountData.version.<get-version>|<get-version>(){}[0]
+
+    final fun component1(): kotlin/UInt // net.avianlabs.solana.domain.core/NonceAccountData.component1|component1(){}[0]
+    final fun component2(): kotlin/UInt // net.avianlabs.solana.domain.core/NonceAccountData.component2|component2(){}[0]
+    final fun component3(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/NonceAccountData.component3|component3(){}[0]
+    final fun component4(): kotlin/String // net.avianlabs.solana.domain.core/NonceAccountData.component4|component4(){}[0]
+    final fun component5(): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.domain.core/NonceAccountData.component5|component5(){}[0]
+    final fun copy(kotlin/UInt = ..., kotlin/UInt = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/String = ..., net.avianlabs.solana.domain.core/FeeCalculator = ...): net.avianlabs.solana.domain.core/NonceAccountData // net.avianlabs.solana.domain.core/NonceAccountData.copy|copy(kotlin.UInt;kotlin.UInt;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;net.avianlabs.solana.domain.core.FeeCalculator){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/NonceAccountData.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/NonceAccountData.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/NonceAccountData.toString|toString(){}[0]
+
+    final object Companion { // net.avianlabs.solana.domain.core/NonceAccountData.Companion|null[0]
+        final fun read(okio/BufferedSource): net.avianlabs.solana.domain.core/NonceAccountData // net.avianlabs.solana.domain.core/NonceAccountData.Companion.read|read(okio.BufferedSource){}[0]
+    }
+}
+
+final class net.avianlabs.solana.domain.core/SignaturePubkeyPair { // net.avianlabs.solana.domain.core/SignaturePubkeyPair|null[0]
+    constructor <init>(kotlin/String, net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.core/SignaturePubkeyPair.<init>|<init>(kotlin.String;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+    final val publicKey // net.avianlabs.solana.domain.core/SignaturePubkeyPair.publicKey|{}publicKey[0]
+        final fun <get-publicKey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/SignaturePubkeyPair.publicKey.<get-publicKey>|<get-publicKey>(){}[0]
+    final val signature // net.avianlabs.solana.domain.core/SignaturePubkeyPair.signature|{}signature[0]
+        final fun <get-signature>(): kotlin/String // net.avianlabs.solana.domain.core/SignaturePubkeyPair.signature.<get-signature>|<get-signature>(){}[0]
+
+    final fun component1(): kotlin/String // net.avianlabs.solana.domain.core/SignaturePubkeyPair.component1|component1(){}[0]
+    final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/SignaturePubkeyPair.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/SignaturePubkeyPair // net.avianlabs.solana.domain.core/SignaturePubkeyPair.copy|copy(kotlin.String;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/SignaturePubkeyPair.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/SignaturePubkeyPair.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/SignaturePubkeyPair.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.domain.core/SignaturePublicKeyPair { // net.avianlabs.solana.domain.core/SignaturePublicKeyPair|null[0]
+    constructor <init>(kotlin/ByteArray?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.<init>|<init>(kotlin.ByteArray?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+    final val publicKey // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.publicKey|{}publicKey[0]
+        final fun <get-publicKey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.publicKey.<get-publicKey>|<get-publicKey>(){}[0]
+    final val signature // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.signature|{}signature[0]
+        final fun <get-signature>(): kotlin/ByteArray? // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.signature.<get-signature>|<get-signature>(){}[0]
+
+    final fun component1(): kotlin/ByteArray? // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.component1|component1(){}[0]
+    final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.component2|component2(){}[0]
+    final fun copy(kotlin/ByteArray? = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/SignaturePublicKeyPair // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.copy|copy(kotlin.ByteArray?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/SignaturePublicKeyPair.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.domain.core/SignedTransaction { // net.avianlabs.solana.domain.core/SignedTransaction|null[0]
+    constructor <init>(net.avianlabs.solana.domain.core/VersionedMessage, kotlin/ByteArray, kotlin.collections/Map<net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ByteArray>, kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey>) // net.avianlabs.solana.domain.core/SignedTransaction.<init>|<init>(net.avianlabs.solana.domain.core.VersionedMessage;kotlin.ByteArray;kotlin.collections.Map<net.avianlabs.solana.tweetnacl.ed25519.PublicKey,kotlin.ByteArray>;kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.PublicKey>){}[0]
+
+    final val message // net.avianlabs.solana.domain.core/SignedTransaction.message|{}message[0]
+        final fun <get-message>(): net.avianlabs.solana.domain.core/VersionedMessage // net.avianlabs.solana.domain.core/SignedTransaction.message.<get-message>|<get-message>(){}[0]
+    final val serializedMessage // net.avianlabs.solana.domain.core/SignedTransaction.serializedMessage|{}serializedMessage[0]
+        final fun <get-serializedMessage>(): kotlin/ByteArray // net.avianlabs.solana.domain.core/SignedTransaction.serializedMessage.<get-serializedMessage>|<get-serializedMessage>(){}[0]
+    final val signatures // net.avianlabs.solana.domain.core/SignedTransaction.signatures|{}signatures[0]
+        final fun <get-signatures>(): kotlin.collections/Map<net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ByteArray> // net.avianlabs.solana.domain.core/SignedTransaction.signatures.<get-signatures>|<get-signatures>(){}[0]
+    final val signerKeys // net.avianlabs.solana.domain.core/SignedTransaction.signerKeys|{}signerKeys[0]
+        final fun <get-signerKeys>(): kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey> // net.avianlabs.solana.domain.core/SignedTransaction.signerKeys.<get-signerKeys>|<get-signerKeys>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.domain.core/VersionedMessage // net.avianlabs.solana.domain.core/SignedTransaction.component1|component1(){}[0]
+    final fun component2(): kotlin/ByteArray // net.avianlabs.solana.domain.core/SignedTransaction.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ByteArray> // net.avianlabs.solana.domain.core/SignedTransaction.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey> // net.avianlabs.solana.domain.core/SignedTransaction.component4|component4(){}[0]
+    final fun copy(net.avianlabs.solana.domain.core/VersionedMessage = ..., kotlin/ByteArray = ..., kotlin.collections/Map<net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ByteArray> = ..., kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey> = ...): net.avianlabs.solana.domain.core/SignedTransaction // net.avianlabs.solana.domain.core/SignedTransaction.copy|copy(net.avianlabs.solana.domain.core.VersionedMessage;kotlin.ByteArray;kotlin.collections.Map<net.avianlabs.solana.tweetnacl.ed25519.PublicKey,kotlin.ByteArray>;kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.PublicKey>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/SignedTransaction.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/SignedTransaction.hashCode|hashCode(){}[0]
+    final fun serialize(kotlin/Boolean = ...): net.avianlabs.solana.domain.core/SerializedTransaction // net.avianlabs.solana.domain.core/SignedTransaction.serialize|serialize(kotlin.Boolean){}[0]
+    final fun sign(kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair>): net.avianlabs.solana.domain.core/SignedTransaction // net.avianlabs.solana.domain.core/SignedTransaction.sign|sign(kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair>){}[0]
+    final fun sign(net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair): net.avianlabs.solana.domain.core/SignedTransaction // net.avianlabs.solana.domain.core/SignedTransaction.sign|sign(net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/SignedTransaction.toString|toString(){}[0]
+
+    final object Companion { // net.avianlabs.solana.domain.core/SignedTransaction.Companion|null[0]
+        final fun sign(net.avianlabs.solana.domain.core/VersionedMessage, kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair>): net.avianlabs.solana.domain.core/SignedTransaction // net.avianlabs.solana.domain.core/SignedTransaction.Companion.sign|sign(net.avianlabs.solana.domain.core.VersionedMessage;kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair>){}[0]
+    }
+}
+
+final class net.avianlabs.solana.domain.core/Transaction { // net.avianlabs.solana.domain.core/Transaction|null[0]
+    final val message // net.avianlabs.solana.domain.core/Transaction.message|{}message[0]
+        final fun <get-message>(): net.avianlabs.solana.domain.core/Message // net.avianlabs.solana.domain.core/Transaction.message.<get-message>|<get-message>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/Transaction.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/Transaction.hashCode|hashCode(){}[0]
+    final fun newBuilder(): net.avianlabs.solana.domain.core/Transaction.Builder // net.avianlabs.solana.domain.core/Transaction.newBuilder|newBuilder(){}[0]
+    final fun sign(kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair>): net.avianlabs.solana.domain.core/SignedTransaction // net.avianlabs.solana.domain.core/Transaction.sign|sign(kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair>){}[0]
+    final fun sign(net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair): net.avianlabs.solana.domain.core/SignedTransaction // net.avianlabs.solana.domain.core/Transaction.sign|sign(net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/Transaction.toString|toString(){}[0]
+
+    final class Builder { // net.avianlabs.solana.domain.core/Transaction.Builder|null[0]
+        constructor <init>() // net.avianlabs.solana.domain.core/Transaction.Builder.<init>|<init>(){}[0]
+
+        final fun addInstruction(net.avianlabs.solana.domain.core/TransactionInstruction): net.avianlabs.solana.domain.core/Transaction.Builder // net.avianlabs.solana.domain.core/Transaction.Builder.addInstruction|addInstruction(net.avianlabs.solana.domain.core.TransactionInstruction){}[0]
+        final fun build(): net.avianlabs.solana.domain.core/Transaction // net.avianlabs.solana.domain.core/Transaction.Builder.build|build(){}[0]
+        final fun setFeePayer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/Transaction.Builder // net.avianlabs.solana.domain.core/Transaction.Builder.setFeePayer|setFeePayer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun setRecentBlockHash(kotlin/String): net.avianlabs.solana.domain.core/Transaction.Builder // net.avianlabs.solana.domain.core/Transaction.Builder.setRecentBlockHash|setRecentBlockHash(kotlin.String){}[0]
+    }
+}
+
+final class net.avianlabs.solana.domain.core/TransactionInstruction { // net.avianlabs.solana.domain.core/TransactionInstruction|null[0]
+    constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta>, kotlin/ByteArray) // net.avianlabs.solana.domain.core/TransactionInstruction.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<net.avianlabs.solana.domain.core.AccountMeta>;kotlin.ByteArray){}[0]
+
+    final val data // net.avianlabs.solana.domain.core/TransactionInstruction.data|{}data[0]
+        final fun <get-data>(): kotlin/ByteArray // net.avianlabs.solana.domain.core/TransactionInstruction.data.<get-data>|<get-data>(){}[0]
+    final val keys // net.avianlabs.solana.domain.core/TransactionInstruction.keys|{}keys[0]
+        final fun <get-keys>(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> // net.avianlabs.solana.domain.core/TransactionInstruction.keys.<get-keys>|<get-keys>(){}[0]
+    final val programId // net.avianlabs.solana.domain.core/TransactionInstruction.programId|{}programId[0]
+        final fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/TransactionInstruction.programId.<get-programId>|<get-programId>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/TransactionInstruction.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> // net.avianlabs.solana.domain.core/TransactionInstruction.component2|component2(){}[0]
+    final fun component3(): kotlin/ByteArray // net.avianlabs.solana.domain.core/TransactionInstruction.component3|component3(){}[0]
+    final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> = ..., kotlin/ByteArray = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.core/TransactionInstruction.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<net.avianlabs.solana.domain.core.AccountMeta>;kotlin.ByteArray){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/TransactionInstruction.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/TransactionInstruction.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/TransactionInstruction.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.domain.core/VersionedTransaction { // net.avianlabs.solana.domain.core/VersionedTransaction|null[0]
+    constructor <init>(net.avianlabs.solana.domain.core/VersionedMessage, kotlin.collections/Map<net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ByteArray> = ...) // net.avianlabs.solana.domain.core/VersionedTransaction.<init>|<init>(net.avianlabs.solana.domain.core.VersionedMessage;kotlin.collections.Map<net.avianlabs.solana.tweetnacl.ed25519.PublicKey,kotlin.ByteArray>){}[0]
+
+    final val message // net.avianlabs.solana.domain.core/VersionedTransaction.message|{}message[0]
+        final fun <get-message>(): net.avianlabs.solana.domain.core/VersionedMessage // net.avianlabs.solana.domain.core/VersionedTransaction.message.<get-message>|<get-message>(){}[0]
+    final val serializedMessage // net.avianlabs.solana.domain.core/VersionedTransaction.serializedMessage|{}serializedMessage[0]
+        final fun <get-serializedMessage>(): kotlin/ByteArray // net.avianlabs.solana.domain.core/VersionedTransaction.serializedMessage.<get-serializedMessage>|<get-serializedMessage>(){}[0]
+    final val signatures // net.avianlabs.solana.domain.core/VersionedTransaction.signatures|{}signatures[0]
+        final fun <get-signatures>(): kotlin.collections/Map<net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ByteArray> // net.avianlabs.solana.domain.core/VersionedTransaction.signatures.<get-signatures>|<get-signatures>(){}[0]
+    final val signerKeys // net.avianlabs.solana.domain.core/VersionedTransaction.signerKeys|{}signerKeys[0]
+        final fun <get-signerKeys>(): kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/PublicKey> // net.avianlabs.solana.domain.core/VersionedTransaction.signerKeys.<get-signerKeys>|<get-signerKeys>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/VersionedTransaction.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/VersionedTransaction.hashCode|hashCode(){}[0]
+    final fun serialize(): net.avianlabs.solana.domain.core/SerializedTransaction // net.avianlabs.solana.domain.core/VersionedTransaction.serialize|serialize(){}[0]
+    final fun sign(kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair>): net.avianlabs.solana.domain.core/VersionedTransaction // net.avianlabs.solana.domain.core/VersionedTransaction.sign|sign(kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair>){}[0]
+    final fun sign(net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair): net.avianlabs.solana.domain.core/VersionedTransaction // net.avianlabs.solana.domain.core/VersionedTransaction.sign|sign(net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/VersionedTransaction.toString|toString(){}[0]
+
+    final class Builder { // net.avianlabs.solana.domain.core/VersionedTransaction.Builder|null[0]
+        constructor <init>() // net.avianlabs.solana.domain.core/VersionedTransaction.Builder.<init>|<init>(){}[0]
+
+        final fun addAddressLookupTableAccount(net.avianlabs.solana.domain.core/AddressLookupTableAccount): net.avianlabs.solana.domain.core/VersionedTransaction.Builder // net.avianlabs.solana.domain.core/VersionedTransaction.Builder.addAddressLookupTableAccount|addAddressLookupTableAccount(net.avianlabs.solana.domain.core.AddressLookupTableAccount){}[0]
+        final fun addInstruction(net.avianlabs.solana.domain.core/TransactionInstruction): net.avianlabs.solana.domain.core/VersionedTransaction.Builder // net.avianlabs.solana.domain.core/VersionedTransaction.Builder.addInstruction|addInstruction(net.avianlabs.solana.domain.core.TransactionInstruction){}[0]
+        final fun build(): net.avianlabs.solana.domain.core/VersionedTransaction // net.avianlabs.solana.domain.core/VersionedTransaction.Builder.build|build(){}[0]
+        final fun buildLegacy(): net.avianlabs.solana.domain.core/VersionedTransaction // net.avianlabs.solana.domain.core/VersionedTransaction.Builder.buildLegacy|buildLegacy(){}[0]
+        final fun buildV0(): net.avianlabs.solana.domain.core/VersionedTransaction // net.avianlabs.solana.domain.core/VersionedTransaction.Builder.buildV0|buildV0(){}[0]
+        final fun setFeePayer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/VersionedTransaction.Builder // net.avianlabs.solana.domain.core/VersionedTransaction.Builder.setFeePayer|setFeePayer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun setRecentBlockHash(kotlin/String): net.avianlabs.solana.domain.core/VersionedTransaction.Builder // net.avianlabs.solana.domain.core/VersionedTransaction.Builder.setRecentBlockHash|setRecentBlockHash(kotlin.String){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.domain.core/VersionedTransaction.Companion|null[0]
+        final fun deserialize(kotlin/ByteArray): net.avianlabs.solana.domain.core/VersionedTransaction // net.avianlabs.solana.domain.core/VersionedTransaction.Companion.deserialize|deserialize(kotlin.ByteArray){}[0]
+    }
+}
+
+final class net.avianlabs.solana.domain.program/ProgramDerivedAddress { // net.avianlabs.solana.domain.program/ProgramDerivedAddress|null[0]
+    constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte) // net.avianlabs.solana.domain.program/ProgramDerivedAddress.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte){}[0]
+
+    final val address // net.avianlabs.solana.domain.program/ProgramDerivedAddress.address|{}address[0]
+        final fun <get-address>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/ProgramDerivedAddress.address.<get-address>|<get-address>(){}[0]
+    final val nonce // net.avianlabs.solana.domain.program/ProgramDerivedAddress.nonce|{}nonce[0]
+        final fun <get-nonce>(): kotlin/UByte // net.avianlabs.solana.domain.program/ProgramDerivedAddress.nonce.<get-nonce>|<get-nonce>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/ProgramDerivedAddress.component1|component1(){}[0]
+    final fun component2(): kotlin/UByte // net.avianlabs.solana.domain.program/ProgramDerivedAddress.component2|component2(){}[0]
+    final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/UByte = ...): net.avianlabs.solana.domain.program/ProgramDerivedAddress // net.avianlabs.solana.domain.program/ProgramDerivedAddress.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/ProgramDerivedAddress.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/ProgramDerivedAddress.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/ProgramDerivedAddress.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.methods/AccountInfo { // net.avianlabs.solana.methods/AccountInfo|null[0]
+    constructor <init>(kotlin/Boolean, kotlin/String, kotlin/ULong, kotlin.collections/List<kotlin/String>, kotlin/ULong) // net.avianlabs.solana.methods/AccountInfo.<init>|<init>(kotlin.Boolean;kotlin.String;kotlin.ULong;kotlin.collections.List<kotlin.String>;kotlin.ULong){}[0]
+
+    final val data // net.avianlabs.solana.methods/AccountInfo.data|{}data[0]
+        final fun <get-data>(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/AccountInfo.data.<get-data>|<get-data>(){}[0]
+    final val dataBytes // net.avianlabs.solana.methods/AccountInfo.dataBytes|{}dataBytes[0]
+        final fun <get-dataBytes>(): kotlin/ByteArray // net.avianlabs.solana.methods/AccountInfo.dataBytes.<get-dataBytes>|<get-dataBytes>(){}[0]
+    final val executable // net.avianlabs.solana.methods/AccountInfo.executable|{}executable[0]
+        final fun <get-executable>(): kotlin/Boolean // net.avianlabs.solana.methods/AccountInfo.executable.<get-executable>|<get-executable>(){}[0]
+    final val lamports // net.avianlabs.solana.methods/AccountInfo.lamports|{}lamports[0]
+        final fun <get-lamports>(): kotlin/ULong // net.avianlabs.solana.methods/AccountInfo.lamports.<get-lamports>|<get-lamports>(){}[0]
+    final val owner // net.avianlabs.solana.methods/AccountInfo.owner|{}owner[0]
+        final fun <get-owner>(): kotlin/String // net.avianlabs.solana.methods/AccountInfo.owner.<get-owner>|<get-owner>(){}[0]
+    final val ownerPublicKey // net.avianlabs.solana.methods/AccountInfo.ownerPublicKey|{}ownerPublicKey[0]
+        final fun <get-ownerPublicKey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.methods/AccountInfo.ownerPublicKey.<get-ownerPublicKey>|<get-ownerPublicKey>(){}[0]
+    final val rentEpoch // net.avianlabs.solana.methods/AccountInfo.rentEpoch|{}rentEpoch[0]
+        final fun <get-rentEpoch>(): kotlin/ULong // net.avianlabs.solana.methods/AccountInfo.rentEpoch.<get-rentEpoch>|<get-rentEpoch>(){}[0]
+
+    final fun component1(): kotlin/Boolean // net.avianlabs.solana.methods/AccountInfo.component1|component1(){}[0]
+    final fun component2(): kotlin/String // net.avianlabs.solana.methods/AccountInfo.component2|component2(){}[0]
+    final fun component3(): kotlin/ULong // net.avianlabs.solana.methods/AccountInfo.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/AccountInfo.component4|component4(){}[0]
+    final fun component5(): kotlin/ULong // net.avianlabs.solana.methods/AccountInfo.component5|component5(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/String = ..., kotlin/ULong = ..., kotlin.collections/List<kotlin/String> = ..., kotlin/ULong = ...): net.avianlabs.solana.methods/AccountInfo // net.avianlabs.solana.methods/AccountInfo.copy|copy(kotlin.Boolean;kotlin.String;kotlin.ULong;kotlin.collections.List<kotlin.String>;kotlin.ULong){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/AccountInfo.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/AccountInfo.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.methods/AccountInfo.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/AccountInfo> { // net.avianlabs.solana.methods/AccountInfo.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.methods/AccountInfo.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/AccountInfo.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/AccountInfo.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/AccountInfo // net.avianlabs.solana.methods/AccountInfo.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/AccountInfo) // net.avianlabs.solana.methods/AccountInfo.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.AccountInfo){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.methods/AccountInfo.Companion|null[0]
+        final val $childSerializers // net.avianlabs.solana.methods/AccountInfo.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/AccountInfo> // net.avianlabs.solana.methods/AccountInfo.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.methods/LatestBlockHash { // net.avianlabs.solana.methods/LatestBlockHash|null[0]
+    constructor <init>(kotlin/String, kotlin/Long) // net.avianlabs.solana.methods/LatestBlockHash.<init>|<init>(kotlin.String;kotlin.Long){}[0]
+
+    final val blockhash // net.avianlabs.solana.methods/LatestBlockHash.blockhash|{}blockhash[0]
+        final fun <get-blockhash>(): kotlin/String // net.avianlabs.solana.methods/LatestBlockHash.blockhash.<get-blockhash>|<get-blockhash>(){}[0]
+    final val lastValidBlockHeight // net.avianlabs.solana.methods/LatestBlockHash.lastValidBlockHeight|{}lastValidBlockHeight[0]
+        final fun <get-lastValidBlockHeight>(): kotlin/Long // net.avianlabs.solana.methods/LatestBlockHash.lastValidBlockHeight.<get-lastValidBlockHeight>|<get-lastValidBlockHeight>(){}[0]
+
+    final fun component1(): kotlin/String // net.avianlabs.solana.methods/LatestBlockHash.component1|component1(){}[0]
+    final fun component2(): kotlin/Long // net.avianlabs.solana.methods/LatestBlockHash.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Long = ...): net.avianlabs.solana.methods/LatestBlockHash // net.avianlabs.solana.methods/LatestBlockHash.copy|copy(kotlin.String;kotlin.Long){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/LatestBlockHash.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/LatestBlockHash.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.methods/LatestBlockHash.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/LatestBlockHash> { // net.avianlabs.solana.methods/LatestBlockHash.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.methods/LatestBlockHash.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/LatestBlockHash.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/LatestBlockHash.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/LatestBlockHash // net.avianlabs.solana.methods/LatestBlockHash.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/LatestBlockHash) // net.avianlabs.solana.methods/LatestBlockHash.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.LatestBlockHash){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.methods/LatestBlockHash.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/LatestBlockHash> // net.avianlabs.solana.methods/LatestBlockHash.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.methods/NonceAccount { // net.avianlabs.solana.methods/NonceAccount|null[0]
+    constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String, net.avianlabs.solana.domain.core/FeeCalculator) // net.avianlabs.solana.methods/NonceAccount.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;net.avianlabs.solana.domain.core.FeeCalculator){}[0]
+
+    final val authorizedPubkey // net.avianlabs.solana.methods/NonceAccount.authorizedPubkey|{}authorizedPubkey[0]
+        final fun <get-authorizedPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.methods/NonceAccount.authorizedPubkey.<get-authorizedPubkey>|<get-authorizedPubkey>(){}[0]
+    final val feeCalculator // net.avianlabs.solana.methods/NonceAccount.feeCalculator|{}feeCalculator[0]
+        final fun <get-feeCalculator>(): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.methods/NonceAccount.feeCalculator.<get-feeCalculator>|<get-feeCalculator>(){}[0]
+    final val nonce // net.avianlabs.solana.methods/NonceAccount.nonce|{}nonce[0]
+        final fun <get-nonce>(): kotlin/String // net.avianlabs.solana.methods/NonceAccount.nonce.<get-nonce>|<get-nonce>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.methods/NonceAccount.component1|component1(){}[0]
+    final fun component2(): kotlin/String // net.avianlabs.solana.methods/NonceAccount.component2|component2(){}[0]
+    final fun component3(): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.methods/NonceAccount.component3|component3(){}[0]
+    final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/String = ..., net.avianlabs.solana.domain.core/FeeCalculator = ...): net.avianlabs.solana.methods/NonceAccount // net.avianlabs.solana.methods/NonceAccount.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;net.avianlabs.solana.domain.core.FeeCalculator){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/NonceAccount.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/NonceAccount.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.methods/NonceAccount.toString|toString(){}[0]
+}
+
+final class net.avianlabs.solana.methods/RecentBlockHash { // net.avianlabs.solana.methods/RecentBlockHash|null[0]
+    constructor <init>(kotlin/String, net.avianlabs.solana.domain.core/FeeCalculator) // net.avianlabs.solana.methods/RecentBlockHash.<init>|<init>(kotlin.String;net.avianlabs.solana.domain.core.FeeCalculator){}[0]
+
+    final val blockhash // net.avianlabs.solana.methods/RecentBlockHash.blockhash|{}blockhash[0]
+        final fun <get-blockhash>(): kotlin/String // net.avianlabs.solana.methods/RecentBlockHash.blockhash.<get-blockhash>|<get-blockhash>(){}[0]
+    final val feeCalculator // net.avianlabs.solana.methods/RecentBlockHash.feeCalculator|{}feeCalculator[0]
+        final fun <get-feeCalculator>(): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.methods/RecentBlockHash.feeCalculator.<get-feeCalculator>|<get-feeCalculator>(){}[0]
+
+    final fun component1(): kotlin/String // net.avianlabs.solana.methods/RecentBlockHash.component1|component1(){}[0]
+    final fun component2(): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.methods/RecentBlockHash.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., net.avianlabs.solana.domain.core/FeeCalculator = ...): net.avianlabs.solana.methods/RecentBlockHash // net.avianlabs.solana.methods/RecentBlockHash.copy|copy(kotlin.String;net.avianlabs.solana.domain.core.FeeCalculator){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/RecentBlockHash.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/RecentBlockHash.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.methods/RecentBlockHash.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/RecentBlockHash> { // net.avianlabs.solana.methods/RecentBlockHash.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.methods/RecentBlockHash.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/RecentBlockHash.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/RecentBlockHash.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/RecentBlockHash // net.avianlabs.solana.methods/RecentBlockHash.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/RecentBlockHash) // net.avianlabs.solana.methods/RecentBlockHash.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.RecentBlockHash){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.methods/RecentBlockHash.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/RecentBlockHash> // net.avianlabs.solana.methods/RecentBlockHash.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.methods/SignatureInformation { // net.avianlabs.solana.methods/SignatureInformation|null[0]
+    constructor <init>(kotlinx.serialization.json/JsonElement?, kotlinx.serialization.json/JsonElement?, kotlin/String?, kotlin/Long?, kotlin/Long?, kotlin/String?) // net.avianlabs.solana.methods/SignatureInformation.<init>|<init>(kotlinx.serialization.json.JsonElement?;kotlinx.serialization.json.JsonElement?;kotlin.String?;kotlin.Long?;kotlin.Long?;kotlin.String?){}[0]
+
+    final val blockTime // net.avianlabs.solana.methods/SignatureInformation.blockTime|{}blockTime[0]
+        final fun <get-blockTime>(): kotlin/Long? // net.avianlabs.solana.methods/SignatureInformation.blockTime.<get-blockTime>|<get-blockTime>(){}[0]
+    final val confirmationStatus // net.avianlabs.solana.methods/SignatureInformation.confirmationStatus|{}confirmationStatus[0]
+        final fun <get-confirmationStatus>(): kotlin/String? // net.avianlabs.solana.methods/SignatureInformation.confirmationStatus.<get-confirmationStatus>|<get-confirmationStatus>(){}[0]
+    final val memo // net.avianlabs.solana.methods/SignatureInformation.memo|{}memo[0]
+        final fun <get-memo>(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/SignatureInformation.memo.<get-memo>|<get-memo>(){}[0]
+    final val signature // net.avianlabs.solana.methods/SignatureInformation.signature|{}signature[0]
+        final fun <get-signature>(): kotlin/String? // net.avianlabs.solana.methods/SignatureInformation.signature.<get-signature>|<get-signature>(){}[0]
+    final val slot // net.avianlabs.solana.methods/SignatureInformation.slot|{}slot[0]
+        final fun <get-slot>(): kotlin/Long? // net.avianlabs.solana.methods/SignatureInformation.slot.<get-slot>|<get-slot>(){}[0]
+
+    final var err // net.avianlabs.solana.methods/SignatureInformation.err|{}err[0]
+        final fun <get-err>(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/SignatureInformation.err.<get-err>|<get-err>(){}[0]
+        final fun <set-err>(kotlinx.serialization.json/JsonElement?) // net.avianlabs.solana.methods/SignatureInformation.err.<set-err>|<set-err>(kotlinx.serialization.json.JsonElement?){}[0]
+
+    final fun component1(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/SignatureInformation.component1|component1(){}[0]
+    final fun component2(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/SignatureInformation.component2|component2(){}[0]
+    final fun component3(): kotlin/String? // net.avianlabs.solana.methods/SignatureInformation.component3|component3(){}[0]
+    final fun component4(): kotlin/Long? // net.avianlabs.solana.methods/SignatureInformation.component4|component4(){}[0]
+    final fun component5(): kotlin/Long? // net.avianlabs.solana.methods/SignatureInformation.component5|component5(){}[0]
+    final fun component6(): kotlin/String? // net.avianlabs.solana.methods/SignatureInformation.component6|component6(){}[0]
+    final fun copy(kotlinx.serialization.json/JsonElement? = ..., kotlinx.serialization.json/JsonElement? = ..., kotlin/String? = ..., kotlin/Long? = ..., kotlin/Long? = ..., kotlin/String? = ...): net.avianlabs.solana.methods/SignatureInformation // net.avianlabs.solana.methods/SignatureInformation.copy|copy(kotlinx.serialization.json.JsonElement?;kotlinx.serialization.json.JsonElement?;kotlin.String?;kotlin.Long?;kotlin.Long?;kotlin.String?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/SignatureInformation.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/SignatureInformation.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.methods/SignatureInformation.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/SignatureInformation> { // net.avianlabs.solana.methods/SignatureInformation.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.methods/SignatureInformation.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/SignatureInformation.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/SignatureInformation.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/SignatureInformation // net.avianlabs.solana.methods/SignatureInformation.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/SignatureInformation) // net.avianlabs.solana.methods/SignatureInformation.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.SignatureInformation){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.methods/SignatureInformation.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/SignatureInformation> // net.avianlabs.solana.methods/SignatureInformation.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.methods/SimulateTransactionResponse { // net.avianlabs.solana.methods/SimulateTransactionResponse|null[0]
+    constructor <init>(kotlinx.serialization.json/JsonElement?, kotlin.collections/List<kotlin/String>?, kotlin.collections/List<net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo>?, kotlin/ULong, net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData?, kotlinx.serialization.json/JsonElement?) // net.avianlabs.solana.methods/SimulateTransactionResponse.<init>|<init>(kotlinx.serialization.json.JsonElement?;kotlin.collections.List<kotlin.String>?;kotlin.collections.List<net.avianlabs.solana.methods.SimulateTransactionResponse.AccountInfo>?;kotlin.ULong;net.avianlabs.solana.methods.SimulateTransactionResponse.ReturnData?;kotlinx.serialization.json.JsonElement?){}[0]
+
+    final val accounts // net.avianlabs.solana.methods/SimulateTransactionResponse.accounts|{}accounts[0]
+        final fun <get-accounts>(): kotlin.collections/List<net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo>? // net.avianlabs.solana.methods/SimulateTransactionResponse.accounts.<get-accounts>|<get-accounts>(){}[0]
+    final val err // net.avianlabs.solana.methods/SimulateTransactionResponse.err|{}err[0]
+        final fun <get-err>(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/SimulateTransactionResponse.err.<get-err>|<get-err>(){}[0]
+    final val innerInstructions // net.avianlabs.solana.methods/SimulateTransactionResponse.innerInstructions|{}innerInstructions[0]
+        final fun <get-innerInstructions>(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/SimulateTransactionResponse.innerInstructions.<get-innerInstructions>|<get-innerInstructions>(){}[0]
+    final val logs // net.avianlabs.solana.methods/SimulateTransactionResponse.logs|{}logs[0]
+        final fun <get-logs>(): kotlin.collections/List<kotlin/String>? // net.avianlabs.solana.methods/SimulateTransactionResponse.logs.<get-logs>|<get-logs>(){}[0]
+    final val returnData // net.avianlabs.solana.methods/SimulateTransactionResponse.returnData|{}returnData[0]
+        final fun <get-returnData>(): net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData? // net.avianlabs.solana.methods/SimulateTransactionResponse.returnData.<get-returnData>|<get-returnData>(){}[0]
+    final val unitsConsumed // net.avianlabs.solana.methods/SimulateTransactionResponse.unitsConsumed|{}unitsConsumed[0]
+        final fun <get-unitsConsumed>(): kotlin/ULong // net.avianlabs.solana.methods/SimulateTransactionResponse.unitsConsumed.<get-unitsConsumed>|<get-unitsConsumed>(){}[0]
+
+    final fun component1(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/SimulateTransactionResponse.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<kotlin/String>? // net.avianlabs.solana.methods/SimulateTransactionResponse.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo>? // net.avianlabs.solana.methods/SimulateTransactionResponse.component3|component3(){}[0]
+    final fun component4(): kotlin/ULong // net.avianlabs.solana.methods/SimulateTransactionResponse.component4|component4(){}[0]
+    final fun component5(): net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData? // net.avianlabs.solana.methods/SimulateTransactionResponse.component5|component5(){}[0]
+    final fun component6(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/SimulateTransactionResponse.component6|component6(){}[0]
+    final fun copy(kotlinx.serialization.json/JsonElement? = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin.collections/List<net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo>? = ..., kotlin/ULong = ..., net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData? = ..., kotlinx.serialization.json/JsonElement? = ...): net.avianlabs.solana.methods/SimulateTransactionResponse // net.avianlabs.solana.methods/SimulateTransactionResponse.copy|copy(kotlinx.serialization.json.JsonElement?;kotlin.collections.List<kotlin.String>?;kotlin.collections.List<net.avianlabs.solana.methods.SimulateTransactionResponse.AccountInfo>?;kotlin.ULong;net.avianlabs.solana.methods.SimulateTransactionResponse.ReturnData?;kotlinx.serialization.json.JsonElement?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/SimulateTransactionResponse.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/SimulateTransactionResponse.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.toString|toString(){}[0]
+
+    final class AccountInfo { // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo|null[0]
+        constructor <init>(kotlin/ULong, kotlin/String, kotlinx.serialization.json/JsonElement, kotlin/Boolean, kotlin/ULong) // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.<init>|<init>(kotlin.ULong;kotlin.String;kotlinx.serialization.json.JsonElement;kotlin.Boolean;kotlin.ULong){}[0]
+
+        final val data // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.data|{}data[0]
+            final fun <get-data>(): kotlinx.serialization.json/JsonElement // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.data.<get-data>|<get-data>(){}[0]
+        final val executable // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.executable|{}executable[0]
+            final fun <get-executable>(): kotlin/Boolean // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.executable.<get-executable>|<get-executable>(){}[0]
+        final val lamports // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.lamports|{}lamports[0]
+            final fun <get-lamports>(): kotlin/ULong // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.lamports.<get-lamports>|<get-lamports>(){}[0]
+        final val owner // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.owner|{}owner[0]
+            final fun <get-owner>(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.owner.<get-owner>|<get-owner>(){}[0]
+        final val rentEpoch // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.rentEpoch|{}rentEpoch[0]
+            final fun <get-rentEpoch>(): kotlin/ULong // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.rentEpoch.<get-rentEpoch>|<get-rentEpoch>(){}[0]
+
+        final fun component1(): kotlin/ULong // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.component1|component1(){}[0]
+        final fun component2(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.component2|component2(){}[0]
+        final fun component3(): kotlinx.serialization.json/JsonElement // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.component3|component3(){}[0]
+        final fun component4(): kotlin/Boolean // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.component4|component4(){}[0]
+        final fun component5(): kotlin/ULong // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.component5|component5(){}[0]
+        final fun copy(kotlin/ULong = ..., kotlin/String = ..., kotlinx.serialization.json/JsonElement = ..., kotlin/Boolean = ..., kotlin/ULong = ...): net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.copy|copy(kotlin.ULong;kotlin.String;kotlinx.serialization.json.JsonElement;kotlin.Boolean;kotlin.ULong){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo> { // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo) // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.SimulateTransactionResponse.AccountInfo){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo> // net.avianlabs.solana.methods/SimulateTransactionResponse.AccountInfo.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class ReturnData { // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData|null[0]
+        constructor <init>(kotlin/String, kotlin/String) // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.<init>|<init>(kotlin.String;kotlin.String){}[0]
+
+        final val data // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.data|{}data[0]
+            final fun <get-data>(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.data.<get-data>|<get-data>(){}[0]
+        final val programId // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.programId|{}programId[0]
+            final fun <get-programId>(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.programId.<get-programId>|<get-programId>(){}[0]
+
+        final fun component1(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.component1|component1(){}[0]
+        final fun component2(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.component2|component2(){}[0]
+        final fun copy(kotlin/String = ..., kotlin/String = ...): net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.copy|copy(kotlin.String;kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData> { // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData) // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.SimulateTransactionResponse.ReturnData){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData> // net.avianlabs.solana.methods/SimulateTransactionResponse.ReturnData.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/SimulateTransactionResponse> { // net.avianlabs.solana.methods/SimulateTransactionResponse.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.methods/SimulateTransactionResponse.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/SimulateTransactionResponse.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/SimulateTransactionResponse.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/SimulateTransactionResponse // net.avianlabs.solana.methods/SimulateTransactionResponse.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/SimulateTransactionResponse) // net.avianlabs.solana.methods/SimulateTransactionResponse.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.SimulateTransactionResponse){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.methods/SimulateTransactionResponse.Companion|null[0]
+        final val $childSerializers // net.avianlabs.solana.methods/SimulateTransactionResponse.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/SimulateTransactionResponse> // net.avianlabs.solana.methods/SimulateTransactionResponse.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.methods/TokenAmountInfo { // net.avianlabs.solana.methods/TokenAmountInfo|null[0]
+    constructor <init>(kotlin/String?, kotlin/Int, kotlin/Double?, kotlin/String) // net.avianlabs.solana.methods/TokenAmountInfo.<init>|<init>(kotlin.String?;kotlin.Int;kotlin.Double?;kotlin.String){}[0]
+
+    final val amount // net.avianlabs.solana.methods/TokenAmountInfo.amount|{}amount[0]
+        final fun <get-amount>(): kotlin/String? // net.avianlabs.solana.methods/TokenAmountInfo.amount.<get-amount>|<get-amount>(){}[0]
+    final val decimals // net.avianlabs.solana.methods/TokenAmountInfo.decimals|{}decimals[0]
+        final fun <get-decimals>(): kotlin/Int // net.avianlabs.solana.methods/TokenAmountInfo.decimals.<get-decimals>|<get-decimals>(){}[0]
+    final val uiAmount // net.avianlabs.solana.methods/TokenAmountInfo.uiAmount|{}uiAmount[0]
+        final fun <get-uiAmount>(): kotlin/Double? // net.avianlabs.solana.methods/TokenAmountInfo.uiAmount.<get-uiAmount>|<get-uiAmount>(){}[0]
+    final val uiAmountString // net.avianlabs.solana.methods/TokenAmountInfo.uiAmountString|{}uiAmountString[0]
+        final fun <get-uiAmountString>(): kotlin/String // net.avianlabs.solana.methods/TokenAmountInfo.uiAmountString.<get-uiAmountString>|<get-uiAmountString>(){}[0]
+
+    final fun component1(): kotlin/String? // net.avianlabs.solana.methods/TokenAmountInfo.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // net.avianlabs.solana.methods/TokenAmountInfo.component2|component2(){}[0]
+    final fun component3(): kotlin/Double? // net.avianlabs.solana.methods/TokenAmountInfo.component3|component3(){}[0]
+    final fun component4(): kotlin/String // net.avianlabs.solana.methods/TokenAmountInfo.component4|component4(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/Int = ..., kotlin/Double? = ..., kotlin/String = ...): net.avianlabs.solana.methods/TokenAmountInfo // net.avianlabs.solana.methods/TokenAmountInfo.copy|copy(kotlin.String?;kotlin.Int;kotlin.Double?;kotlin.String){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TokenAmountInfo.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TokenAmountInfo.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.methods/TokenAmountInfo.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TokenAmountInfo> { // net.avianlabs.solana.methods/TokenAmountInfo.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.methods/TokenAmountInfo.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TokenAmountInfo.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TokenAmountInfo.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TokenAmountInfo // net.avianlabs.solana.methods/TokenAmountInfo.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TokenAmountInfo) // net.avianlabs.solana.methods/TokenAmountInfo.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TokenAmountInfo){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.methods/TokenAmountInfo.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TokenAmountInfo> // net.avianlabs.solana.methods/TokenAmountInfo.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.methods/TransactionResponse { // net.avianlabs.solana.methods/TransactionResponse|null[0]
+    constructor <init>(net.avianlabs.solana.methods/TransactionResponse.Meta?, kotlin/Long?, net.avianlabs.solana.methods/TransactionResponse.Transaction?, kotlin/Long?, kotlinx.serialization.json/JsonElement? = ...) // net.avianlabs.solana.methods/TransactionResponse.<init>|<init>(net.avianlabs.solana.methods.TransactionResponse.Meta?;kotlin.Long?;net.avianlabs.solana.methods.TransactionResponse.Transaction?;kotlin.Long?;kotlinx.serialization.json.JsonElement?){}[0]
+
+    final val blockTime // net.avianlabs.solana.methods/TransactionResponse.blockTime|{}blockTime[0]
+        final fun <get-blockTime>(): kotlin/Long? // net.avianlabs.solana.methods/TransactionResponse.blockTime.<get-blockTime>|<get-blockTime>(){}[0]
+    final val meta // net.avianlabs.solana.methods/TransactionResponse.meta|{}meta[0]
+        final fun <get-meta>(): net.avianlabs.solana.methods/TransactionResponse.Meta? // net.avianlabs.solana.methods/TransactionResponse.meta.<get-meta>|<get-meta>(){}[0]
+    final val slot // net.avianlabs.solana.methods/TransactionResponse.slot|{}slot[0]
+        final fun <get-slot>(): kotlin/Long? // net.avianlabs.solana.methods/TransactionResponse.slot.<get-slot>|<get-slot>(){}[0]
+    final val transaction // net.avianlabs.solana.methods/TransactionResponse.transaction|{}transaction[0]
+        final fun <get-transaction>(): net.avianlabs.solana.methods/TransactionResponse.Transaction? // net.avianlabs.solana.methods/TransactionResponse.transaction.<get-transaction>|<get-transaction>(){}[0]
+    final val version // net.avianlabs.solana.methods/TransactionResponse.version|{}version[0]
+        final fun <get-version>(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/TransactionResponse.version.<get-version>|<get-version>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.methods/TransactionResponse.Meta? // net.avianlabs.solana.methods/TransactionResponse.component1|component1(){}[0]
+    final fun component2(): kotlin/Long? // net.avianlabs.solana.methods/TransactionResponse.component2|component2(){}[0]
+    final fun component3(): net.avianlabs.solana.methods/TransactionResponse.Transaction? // net.avianlabs.solana.methods/TransactionResponse.component3|component3(){}[0]
+    final fun component4(): kotlin/Long? // net.avianlabs.solana.methods/TransactionResponse.component4|component4(){}[0]
+    final fun component5(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/TransactionResponse.component5|component5(){}[0]
+    final fun copy(net.avianlabs.solana.methods/TransactionResponse.Meta? = ..., kotlin/Long? = ..., net.avianlabs.solana.methods/TransactionResponse.Transaction? = ..., kotlin/Long? = ..., kotlinx.serialization.json/JsonElement? = ...): net.avianlabs.solana.methods/TransactionResponse // net.avianlabs.solana.methods/TransactionResponse.copy|copy(net.avianlabs.solana.methods.TransactionResponse.Meta?;kotlin.Long?;net.avianlabs.solana.methods.TransactionResponse.Transaction?;kotlin.Long?;kotlinx.serialization.json.JsonElement?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.toString|toString(){}[0]
+
+    final class AddressTableLookup { // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup|null[0]
+        constructor <init>(kotlin/String, kotlin.collections/List<kotlin/Int>, kotlin.collections/List<kotlin/Int>) // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>){}[0]
+
+        final val accountKey // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.accountKey|{}accountKey[0]
+            final fun <get-accountKey>(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.accountKey.<get-accountKey>|<get-accountKey>(){}[0]
+        final val readonlyIndexes // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.readonlyIndexes|{}readonlyIndexes[0]
+            final fun <get-readonlyIndexes>(): kotlin.collections/List<kotlin/Int> // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.readonlyIndexes.<get-readonlyIndexes>|<get-readonlyIndexes>(){}[0]
+        final val writableIndexes // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.writableIndexes|{}writableIndexes[0]
+            final fun <get-writableIndexes>(): kotlin.collections/List<kotlin/Int> // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.writableIndexes.<get-writableIndexes>|<get-writableIndexes>(){}[0]
+
+        final fun component1(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.component1|component1(){}[0]
+        final fun component2(): kotlin.collections/List<kotlin/Int> // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.component2|component2(){}[0]
+        final fun component3(): kotlin.collections/List<kotlin/Int> // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.component3|component3(){}[0]
+        final fun copy(kotlin/String = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<kotlin/Int> = ...): net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.copy|copy(kotlin.String;kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup> { // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup) // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.AddressTableLookup){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.Companion|null[0]
+            final val $childSerializers // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup> // net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class Header { // net.avianlabs.solana.methods/TransactionResponse.Header|null[0]
+        constructor <init>(kotlin/Long, kotlin/Long, kotlin/Long) // net.avianlabs.solana.methods/TransactionResponse.Header.<init>|<init>(kotlin.Long;kotlin.Long;kotlin.Long){}[0]
+
+        final val numReadonlySignedAccounts // net.avianlabs.solana.methods/TransactionResponse.Header.numReadonlySignedAccounts|{}numReadonlySignedAccounts[0]
+            final fun <get-numReadonlySignedAccounts>(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Header.numReadonlySignedAccounts.<get-numReadonlySignedAccounts>|<get-numReadonlySignedAccounts>(){}[0]
+        final val numReadonlyUnsignedAccounts // net.avianlabs.solana.methods/TransactionResponse.Header.numReadonlyUnsignedAccounts|{}numReadonlyUnsignedAccounts[0]
+            final fun <get-numReadonlyUnsignedAccounts>(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Header.numReadonlyUnsignedAccounts.<get-numReadonlyUnsignedAccounts>|<get-numReadonlyUnsignedAccounts>(){}[0]
+        final val numRequiredSignatures // net.avianlabs.solana.methods/TransactionResponse.Header.numRequiredSignatures|{}numRequiredSignatures[0]
+            final fun <get-numRequiredSignatures>(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Header.numRequiredSignatures.<get-numRequiredSignatures>|<get-numRequiredSignatures>(){}[0]
+
+        final fun component1(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Header.component1|component1(){}[0]
+        final fun component2(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Header.component2|component2(){}[0]
+        final fun component3(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Header.component3|component3(){}[0]
+        final fun copy(kotlin/Long = ..., kotlin/Long = ..., kotlin/Long = ...): net.avianlabs.solana.methods/TransactionResponse.Header // net.avianlabs.solana.methods/TransactionResponse.Header.copy|copy(kotlin.Long;kotlin.Long;kotlin.Long){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.Header.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.Header.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.Header.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.Header> { // net.avianlabs.solana.methods/TransactionResponse.Header.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/TransactionResponse.Header.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.Header.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.Header.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.Header // net.avianlabs.solana.methods/TransactionResponse.Header.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.Header) // net.avianlabs.solana.methods/TransactionResponse.Header.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.Header){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/TransactionResponse.Header.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.Header> // net.avianlabs.solana.methods/TransactionResponse.Header.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class Instruction { // net.avianlabs.solana.methods/TransactionResponse.Instruction|null[0]
+        constructor <init>(kotlin.collections/List<kotlin/Long>?, kotlin/String?, kotlin/Long) // net.avianlabs.solana.methods/TransactionResponse.Instruction.<init>|<init>(kotlin.collections.List<kotlin.Long>?;kotlin.String?;kotlin.Long){}[0]
+
+        final val accounts // net.avianlabs.solana.methods/TransactionResponse.Instruction.accounts|{}accounts[0]
+            final fun <get-accounts>(): kotlin.collections/List<kotlin/Long>? // net.avianlabs.solana.methods/TransactionResponse.Instruction.accounts.<get-accounts>|<get-accounts>(){}[0]
+        final val data // net.avianlabs.solana.methods/TransactionResponse.Instruction.data|{}data[0]
+            final fun <get-data>(): kotlin/String? // net.avianlabs.solana.methods/TransactionResponse.Instruction.data.<get-data>|<get-data>(){}[0]
+        final val programIdIndex // net.avianlabs.solana.methods/TransactionResponse.Instruction.programIdIndex|{}programIdIndex[0]
+            final fun <get-programIdIndex>(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Instruction.programIdIndex.<get-programIdIndex>|<get-programIdIndex>(){}[0]
+
+        final fun component1(): kotlin.collections/List<kotlin/Long>? // net.avianlabs.solana.methods/TransactionResponse.Instruction.component1|component1(){}[0]
+        final fun component2(): kotlin/String? // net.avianlabs.solana.methods/TransactionResponse.Instruction.component2|component2(){}[0]
+        final fun component3(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Instruction.component3|component3(){}[0]
+        final fun copy(kotlin.collections/List<kotlin/Long>? = ..., kotlin/String? = ..., kotlin/Long = ...): net.avianlabs.solana.methods/TransactionResponse.Instruction // net.avianlabs.solana.methods/TransactionResponse.Instruction.copy|copy(kotlin.collections.List<kotlin.Long>?;kotlin.String?;kotlin.Long){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.Instruction.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.Instruction.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.Instruction.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.Instruction> { // net.avianlabs.solana.methods/TransactionResponse.Instruction.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/TransactionResponse.Instruction.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.Instruction.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.Instruction.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.Instruction // net.avianlabs.solana.methods/TransactionResponse.Instruction.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.Instruction) // net.avianlabs.solana.methods/TransactionResponse.Instruction.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.Instruction){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/TransactionResponse.Instruction.Companion|null[0]
+            final val $childSerializers // net.avianlabs.solana.methods/TransactionResponse.Instruction.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.Instruction> // net.avianlabs.solana.methods/TransactionResponse.Instruction.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class LoadedAddresses { // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses|null[0]
+        constructor <init>(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<kotlin/String> = ...) // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.<init>|<init>(kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>){}[0]
+
+        final val readonly // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.readonly|{}readonly[0]
+            final fun <get-readonly>(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.readonly.<get-readonly>|<get-readonly>(){}[0]
+        final val writable // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.writable|{}writable[0]
+            final fun <get-writable>(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.writable.<get-writable>|<get-writable>(){}[0]
+
+        final fun component1(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.component1|component1(){}[0]
+        final fun component2(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.component2|component2(){}[0]
+        final fun copy(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<kotlin/String> = ...): net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.copy|copy(kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses> { // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses) // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.LoadedAddresses){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.Companion|null[0]
+            final val $childSerializers // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses> // net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class Message { // net.avianlabs.solana.methods/TransactionResponse.Message|null[0]
+        constructor <init>(kotlin.collections/List<kotlin/String>, net.avianlabs.solana.methods/TransactionResponse.Header, kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Instruction>, kotlin/String, kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup>? = ...) // net.avianlabs.solana.methods/TransactionResponse.Message.<init>|<init>(kotlin.collections.List<kotlin.String>;net.avianlabs.solana.methods.TransactionResponse.Header;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.Instruction>;kotlin.String;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.AddressTableLookup>?){}[0]
+
+        final val accountKeys // net.avianlabs.solana.methods/TransactionResponse.Message.accountKeys|{}accountKeys[0]
+            final fun <get-accountKeys>(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/TransactionResponse.Message.accountKeys.<get-accountKeys>|<get-accountKeys>(){}[0]
+        final val addressTableLookups // net.avianlabs.solana.methods/TransactionResponse.Message.addressTableLookups|{}addressTableLookups[0]
+            final fun <get-addressTableLookups>(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup>? // net.avianlabs.solana.methods/TransactionResponse.Message.addressTableLookups.<get-addressTableLookups>|<get-addressTableLookups>(){}[0]
+        final val header // net.avianlabs.solana.methods/TransactionResponse.Message.header|{}header[0]
+            final fun <get-header>(): net.avianlabs.solana.methods/TransactionResponse.Header // net.avianlabs.solana.methods/TransactionResponse.Message.header.<get-header>|<get-header>(){}[0]
+        final val instructions // net.avianlabs.solana.methods/TransactionResponse.Message.instructions|{}instructions[0]
+            final fun <get-instructions>(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Instruction> // net.avianlabs.solana.methods/TransactionResponse.Message.instructions.<get-instructions>|<get-instructions>(){}[0]
+        final val recentBlockhash // net.avianlabs.solana.methods/TransactionResponse.Message.recentBlockhash|{}recentBlockhash[0]
+            final fun <get-recentBlockhash>(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.Message.recentBlockhash.<get-recentBlockhash>|<get-recentBlockhash>(){}[0]
+
+        final fun component1(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/TransactionResponse.Message.component1|component1(){}[0]
+        final fun component2(): net.avianlabs.solana.methods/TransactionResponse.Header // net.avianlabs.solana.methods/TransactionResponse.Message.component2|component2(){}[0]
+        final fun component3(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Instruction> // net.avianlabs.solana.methods/TransactionResponse.Message.component3|component3(){}[0]
+        final fun component4(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.Message.component4|component4(){}[0]
+        final fun component5(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup>? // net.avianlabs.solana.methods/TransactionResponse.Message.component5|component5(){}[0]
+        final fun copy(kotlin.collections/List<kotlin/String> = ..., net.avianlabs.solana.methods/TransactionResponse.Header = ..., kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Instruction> = ..., kotlin/String = ..., kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.AddressTableLookup>? = ...): net.avianlabs.solana.methods/TransactionResponse.Message // net.avianlabs.solana.methods/TransactionResponse.Message.copy|copy(kotlin.collections.List<kotlin.String>;net.avianlabs.solana.methods.TransactionResponse.Header;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.Instruction>;kotlin.String;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.AddressTableLookup>?){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.Message.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.Message.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.Message.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.Message> { // net.avianlabs.solana.methods/TransactionResponse.Message.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/TransactionResponse.Message.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.Message.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.Message.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.Message // net.avianlabs.solana.methods/TransactionResponse.Message.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.Message) // net.avianlabs.solana.methods/TransactionResponse.Message.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.Message){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/TransactionResponse.Message.Companion|null[0]
+            final val $childSerializers // net.avianlabs.solana.methods/TransactionResponse.Message.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.Message> // net.avianlabs.solana.methods/TransactionResponse.Message.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class Meta { // net.avianlabs.solana.methods/TransactionResponse.Meta|null[0]
+        constructor <init>(kotlinx.serialization.json/JsonElement?, kotlin/Long, kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta>, kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.TokenBalance>, kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.TokenBalance>, kotlin.collections/List<kotlin/Long>, kotlin.collections/List<kotlin/Long>, kotlin.collections/List<kotlin/String>?, net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses? = ...) // net.avianlabs.solana.methods/TransactionResponse.Meta.<init>|<init>(kotlinx.serialization.json.JsonElement?;kotlin.Long;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.Meta.InnerInstructionMeta>;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.TokenBalance>;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.TokenBalance>;kotlin.collections.List<kotlin.Long>;kotlin.collections.List<kotlin.Long>;kotlin.collections.List<kotlin.String>?;net.avianlabs.solana.methods.TransactionResponse.LoadedAddresses?){}[0]
+
+        final val err // net.avianlabs.solana.methods/TransactionResponse.Meta.err|{}err[0]
+            final fun <get-err>(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/TransactionResponse.Meta.err.<get-err>|<get-err>(){}[0]
+        final val fee // net.avianlabs.solana.methods/TransactionResponse.Meta.fee|{}fee[0]
+            final fun <get-fee>(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Meta.fee.<get-fee>|<get-fee>(){}[0]
+        final val innerInstructions // net.avianlabs.solana.methods/TransactionResponse.Meta.innerInstructions|{}innerInstructions[0]
+            final fun <get-innerInstructions>(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta> // net.avianlabs.solana.methods/TransactionResponse.Meta.innerInstructions.<get-innerInstructions>|<get-innerInstructions>(){}[0]
+        final val loadedAddresses // net.avianlabs.solana.methods/TransactionResponse.Meta.loadedAddresses|{}loadedAddresses[0]
+            final fun <get-loadedAddresses>(): net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses? // net.avianlabs.solana.methods/TransactionResponse.Meta.loadedAddresses.<get-loadedAddresses>|<get-loadedAddresses>(){}[0]
+        final val logMessages // net.avianlabs.solana.methods/TransactionResponse.Meta.logMessages|{}logMessages[0]
+            final fun <get-logMessages>(): kotlin.collections/List<kotlin/String>? // net.avianlabs.solana.methods/TransactionResponse.Meta.logMessages.<get-logMessages>|<get-logMessages>(){}[0]
+        final val postBalances // net.avianlabs.solana.methods/TransactionResponse.Meta.postBalances|{}postBalances[0]
+            final fun <get-postBalances>(): kotlin.collections/List<kotlin/Long> // net.avianlabs.solana.methods/TransactionResponse.Meta.postBalances.<get-postBalances>|<get-postBalances>(){}[0]
+        final val postTokenBalances // net.avianlabs.solana.methods/TransactionResponse.Meta.postTokenBalances|{}postTokenBalances[0]
+            final fun <get-postTokenBalances>(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.TokenBalance> // net.avianlabs.solana.methods/TransactionResponse.Meta.postTokenBalances.<get-postTokenBalances>|<get-postTokenBalances>(){}[0]
+        final val preBalances // net.avianlabs.solana.methods/TransactionResponse.Meta.preBalances|{}preBalances[0]
+            final fun <get-preBalances>(): kotlin.collections/List<kotlin/Long> // net.avianlabs.solana.methods/TransactionResponse.Meta.preBalances.<get-preBalances>|<get-preBalances>(){}[0]
+        final val preTokenBalances // net.avianlabs.solana.methods/TransactionResponse.Meta.preTokenBalances|{}preTokenBalances[0]
+            final fun <get-preTokenBalances>(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.TokenBalance> // net.avianlabs.solana.methods/TransactionResponse.Meta.preTokenBalances.<get-preTokenBalances>|<get-preTokenBalances>(){}[0]
+
+        final fun component1(): kotlinx.serialization.json/JsonElement? // net.avianlabs.solana.methods/TransactionResponse.Meta.component1|component1(){}[0]
+        final fun component2(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Meta.component2|component2(){}[0]
+        final fun component3(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta> // net.avianlabs.solana.methods/TransactionResponse.Meta.component3|component3(){}[0]
+        final fun component4(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.TokenBalance> // net.avianlabs.solana.methods/TransactionResponse.Meta.component4|component4(){}[0]
+        final fun component5(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.TokenBalance> // net.avianlabs.solana.methods/TransactionResponse.Meta.component5|component5(){}[0]
+        final fun component6(): kotlin.collections/List<kotlin/Long> // net.avianlabs.solana.methods/TransactionResponse.Meta.component6|component6(){}[0]
+        final fun component7(): kotlin.collections/List<kotlin/Long> // net.avianlabs.solana.methods/TransactionResponse.Meta.component7|component7(){}[0]
+        final fun component8(): kotlin.collections/List<kotlin/String>? // net.avianlabs.solana.methods/TransactionResponse.Meta.component8|component8(){}[0]
+        final fun component9(): net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses? // net.avianlabs.solana.methods/TransactionResponse.Meta.component9|component9(){}[0]
+        final fun copy(kotlinx.serialization.json/JsonElement? = ..., kotlin/Long = ..., kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta> = ..., kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.TokenBalance> = ..., kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.TokenBalance> = ..., kotlin.collections/List<kotlin/Long> = ..., kotlin.collections/List<kotlin/Long> = ..., kotlin.collections/List<kotlin/String>? = ..., net.avianlabs.solana.methods/TransactionResponse.LoadedAddresses? = ...): net.avianlabs.solana.methods/TransactionResponse.Meta // net.avianlabs.solana.methods/TransactionResponse.Meta.copy|copy(kotlinx.serialization.json.JsonElement?;kotlin.Long;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.Meta.InnerInstructionMeta>;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.TokenBalance>;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.TokenBalance>;kotlin.collections.List<kotlin.Long>;kotlin.collections.List<kotlin.Long>;kotlin.collections.List<kotlin.String>?;net.avianlabs.solana.methods.TransactionResponse.LoadedAddresses?){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.Meta.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.Meta.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.Meta.toString|toString(){}[0]
+
+        final class InnerInstructionMeta { // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta|null[0]
+            constructor <init>(kotlin/Long, kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Instruction>) // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.<init>|<init>(kotlin.Long;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.Instruction>){}[0]
+
+            final val index // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.index|{}index[0]
+                final fun <get-index>(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.index.<get-index>|<get-index>(){}[0]
+            final val instructions // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.instructions|{}instructions[0]
+                final fun <get-instructions>(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Instruction> // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.instructions.<get-instructions>|<get-instructions>(){}[0]
+
+            final fun component1(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.component1|component1(){}[0]
+            final fun component2(): kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Instruction> // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.component2|component2(){}[0]
+            final fun copy(kotlin/Long = ..., kotlin.collections/List<net.avianlabs.solana.methods/TransactionResponse.Instruction> = ...): net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.copy|copy(kotlin.Long;kotlin.collections.List<net.avianlabs.solana.methods.TransactionResponse.Instruction>){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.toString|toString(){}[0]
+
+            final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta> { // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.$serializer|null[0]
+                final val descriptor // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.$serializer.descriptor|{}descriptor[0]
+                    final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+                final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.$serializer.childSerializers|childSerializers(){}[0]
+                final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+                final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta) // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.Meta.InnerInstructionMeta){}[0]
+            }
+
+            final object Companion { // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.Companion|null[0]
+                final val $childSerializers // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.Companion.$childSerializers|{}$childSerializers[0]
+
+                final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta> // net.avianlabs.solana.methods/TransactionResponse.Meta.InnerInstructionMeta.Companion.serializer|serializer(){}[0]
+            }
+        }
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.Meta> { // net.avianlabs.solana.methods/TransactionResponse.Meta.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/TransactionResponse.Meta.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.Meta.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.Meta.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.Meta // net.avianlabs.solana.methods/TransactionResponse.Meta.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.Meta) // net.avianlabs.solana.methods/TransactionResponse.Meta.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.Meta){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/TransactionResponse.Meta.Companion|null[0]
+            final val $childSerializers // net.avianlabs.solana.methods/TransactionResponse.Meta.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.Meta> // net.avianlabs.solana.methods/TransactionResponse.Meta.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class TokenBalance { // net.avianlabs.solana.methods/TransactionResponse.TokenBalance|null[0]
+        constructor <init>(kotlin/Long, kotlin/String, net.avianlabs.solana.methods/TokenAmountInfo) // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.<init>|<init>(kotlin.Long;kotlin.String;net.avianlabs.solana.methods.TokenAmountInfo){}[0]
+
+        final val accountIndex // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.accountIndex|{}accountIndex[0]
+            final fun <get-accountIndex>(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.accountIndex.<get-accountIndex>|<get-accountIndex>(){}[0]
+        final val mint // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.mint|{}mint[0]
+            final fun <get-mint>(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.mint.<get-mint>|<get-mint>(){}[0]
+        final val uiTokenAmount // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.uiTokenAmount|{}uiTokenAmount[0]
+            final fun <get-uiTokenAmount>(): net.avianlabs.solana.methods/TokenAmountInfo // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.uiTokenAmount.<get-uiTokenAmount>|<get-uiTokenAmount>(){}[0]
+
+        final fun component1(): kotlin/Long // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.component1|component1(){}[0]
+        final fun component2(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.component2|component2(){}[0]
+        final fun component3(): net.avianlabs.solana.methods/TokenAmountInfo // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.component3|component3(){}[0]
+        final fun copy(kotlin/Long = ..., kotlin/String = ..., net.avianlabs.solana.methods/TokenAmountInfo = ...): net.avianlabs.solana.methods/TransactionResponse.TokenBalance // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.copy|copy(kotlin.Long;kotlin.String;net.avianlabs.solana.methods.TokenAmountInfo){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.TokenBalance> { // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.TokenBalance // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.TokenBalance) // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.TokenBalance){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.TokenBalance> // net.avianlabs.solana.methods/TransactionResponse.TokenBalance.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final class Transaction { // net.avianlabs.solana.methods/TransactionResponse.Transaction|null[0]
+        constructor <init>(net.avianlabs.solana.methods/TransactionResponse.Message, kotlin.collections/List<kotlin/String>) // net.avianlabs.solana.methods/TransactionResponse.Transaction.<init>|<init>(net.avianlabs.solana.methods.TransactionResponse.Message;kotlin.collections.List<kotlin.String>){}[0]
+
+        final val message // net.avianlabs.solana.methods/TransactionResponse.Transaction.message|{}message[0]
+            final fun <get-message>(): net.avianlabs.solana.methods/TransactionResponse.Message // net.avianlabs.solana.methods/TransactionResponse.Transaction.message.<get-message>|<get-message>(){}[0]
+        final val signatures // net.avianlabs.solana.methods/TransactionResponse.Transaction.signatures|{}signatures[0]
+            final fun <get-signatures>(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/TransactionResponse.Transaction.signatures.<get-signatures>|<get-signatures>(){}[0]
+
+        final fun component1(): net.avianlabs.solana.methods/TransactionResponse.Message // net.avianlabs.solana.methods/TransactionResponse.Transaction.component1|component1(){}[0]
+        final fun component2(): kotlin.collections/List<kotlin/String> // net.avianlabs.solana.methods/TransactionResponse.Transaction.component2|component2(){}[0]
+        final fun copy(net.avianlabs.solana.methods/TransactionResponse.Message = ..., kotlin.collections/List<kotlin/String> = ...): net.avianlabs.solana.methods/TransactionResponse.Transaction // net.avianlabs.solana.methods/TransactionResponse.Transaction.copy|copy(net.avianlabs.solana.methods.TransactionResponse.Message;kotlin.collections.List<kotlin.String>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.methods/TransactionResponse.Transaction.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.methods/TransactionResponse.Transaction.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.methods/TransactionResponse.Transaction.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse.Transaction> { // net.avianlabs.solana.methods/TransactionResponse.Transaction.$serializer|null[0]
+            final val descriptor // net.avianlabs.solana.methods/TransactionResponse.Transaction.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.Transaction.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.Transaction.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse.Transaction // net.avianlabs.solana.methods/TransactionResponse.Transaction.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse.Transaction) // net.avianlabs.solana.methods/TransactionResponse.Transaction.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse.Transaction){}[0]
+        }
+
+        final object Companion { // net.avianlabs.solana.methods/TransactionResponse.Transaction.Companion|null[0]
+            final val $childSerializers // net.avianlabs.solana.methods/TransactionResponse.Transaction.Companion.$childSerializers|{}$childSerializers[0]
+
+            final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse.Transaction> // net.avianlabs.solana.methods/TransactionResponse.Transaction.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<net.avianlabs.solana.methods/TransactionResponse> { // net.avianlabs.solana.methods/TransactionResponse.$serializer|null[0]
+        final val descriptor // net.avianlabs.solana.methods/TransactionResponse.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // net.avianlabs.solana.methods/TransactionResponse.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // net.avianlabs.solana.methods/TransactionResponse.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): net.avianlabs.solana.methods/TransactionResponse // net.avianlabs.solana.methods/TransactionResponse.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, net.avianlabs.solana.methods/TransactionResponse) // net.avianlabs.solana.methods/TransactionResponse.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;net.avianlabs.solana.methods.TransactionResponse){}[0]
+    }
+
+    final object Companion { // net.avianlabs.solana.methods/TransactionResponse.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.methods/TransactionResponse> // net.avianlabs.solana.methods/TransactionResponse.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class net.avianlabs.solana/SolanaClient { // net.avianlabs.solana/SolanaClient|null[0]
+    constructor <init>(kotlin/String, kotlin.coroutines/SuspendFunction0<kotlin/String?>? = ...) // net.avianlabs.solana/SolanaClient.<init>|<init>(kotlin.String;kotlin.coroutines.SuspendFunction0<kotlin.String?>?){}[0]
+    constructor <init>(net.avianlabs.solana.client/RpcKtorClient, kotlin.collections/Map<kotlin/String, kotlin.coroutines/SuspendFunction0<kotlin/String?>> = ...) // net.avianlabs.solana/SolanaClient.<init>|<init>(net.avianlabs.solana.client.RpcKtorClient;kotlin.collections.Map<kotlin.String,kotlin.coroutines.SuspendFunction0<kotlin.String?>>){}[0]
+}
+
+final value class net.avianlabs.solana.domain.core/SerializedTransaction { // net.avianlabs.solana.domain.core/SerializedTransaction|null[0]
+    constructor <init>(kotlin/ByteArray) // net.avianlabs.solana.domain.core/SerializedTransaction.<init>|<init>(kotlin.ByteArray){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/SerializedTransaction.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/SerializedTransaction.hashCode|hashCode(){}[0]
+    final fun sign(kotlin.collections/List<net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair>): net.avianlabs.solana.domain.core/SerializedTransaction // net.avianlabs.solana.domain.core/SerializedTransaction.sign|sign(kotlin.collections.List<net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair>){}[0]
+    final fun sign(net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair): net.avianlabs.solana.domain.core/SerializedTransaction // net.avianlabs.solana.domain.core/SerializedTransaction.sign|sign(net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair){}[0]
+    final fun toByteArray(): kotlin/ByteArray // net.avianlabs.solana.domain.core/SerializedTransaction.toByteArray|toByteArray(){}[0]
+    final fun toSignedTransaction(): net.avianlabs.solana.domain.core/SignedTransaction // net.avianlabs.solana.domain.core/SerializedTransaction.toSignedTransaction|toSignedTransaction(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/SerializedTransaction.toString|toString(){}[0]
+    final fun toVersionedTransaction(): net.avianlabs.solana.domain.core/VersionedTransaction // net.avianlabs.solana.domain.core/SerializedTransaction.toVersionedTransaction|toVersionedTransaction(){}[0]
+}
+
+sealed class net.avianlabs.solana.domain.core/DecodedInstruction { // net.avianlabs.solana.domain.core/DecodedInstruction|null[0]
+    open val program // net.avianlabs.solana.domain.core/DecodedInstruction.program|{}program[0]
+        open fun <get-program>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.program.<get-program>|<get-program>(){}[0]
+
+    final class Raw : net.avianlabs.solana.domain.core/DecodedInstruction { // net.avianlabs.solana.domain.core/DecodedInstruction.Raw|null[0]
+        constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta>?, kotlin/ByteArray?) // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<net.avianlabs.solana.domain.core.AccountMeta>?;kotlin.ByteArray?){}[0]
+
+        final val accounts // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.accounts|{}accounts[0]
+            final fun <get-accounts>(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta>? // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.accounts.<get-accounts>|<get-accounts>(){}[0]
+        final val data // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.data|{}data[0]
+            final fun <get-data>(): kotlin/ByteArray? // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.data.<get-data>|<get-data>(){}[0]
+        final val program // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.program|{}program[0]
+            final fun <get-program>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.program.<get-program>|<get-program>(){}[0]
+
+        final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.component1|component1(){}[0]
+        final fun component2(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta>? // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.component2|component2(){}[0]
+        final fun component3(): kotlin/ByteArray? // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.component3|component3(){}[0]
+        final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta>? = ..., kotlin/ByteArray? = ...): net.avianlabs.solana.domain.core/DecodedInstruction.Raw // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<net.avianlabs.solana.domain.core.AccountMeta>?;kotlin.ByteArray?){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.Raw.toString|toString(){}[0]
+    }
+
+    sealed class AssociatedTokenProgram : net.avianlabs.solana.domain.core/DecodedInstruction { // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram|null[0]
+        final class CreatedAssociatedAccount : net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+            final val associatedAccount // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.associatedAccount|{}associatedAccount[0]
+                final fun <get-associatedAccount>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.associatedAccount.<get-associatedAccount>|<get-associatedAccount>(){}[0]
+            final val mint // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.mint|{}mint[0]
+                final fun <get-mint>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.mint.<get-mint>|<get-mint>(){}[0]
+            final val owner // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.owner|{}owner[0]
+                final fun <get-owner>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.owner.<get-owner>|<get-owner>(){}[0]
+            final val payer // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.payer|{}payer[0]
+                final fun <get-payer>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.payer.<get-payer>|<get-payer>(){}[0]
+            final val programId // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.programId|{}programId[0]
+                final fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.programId.<get-programId>|<get-programId>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.component2|component2(){}[0]
+            final fun component3(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.component3|component3(){}[0]
+            final fun component4(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.component4|component4(){}[0]
+            final fun component5(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.component5|component5(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.AssociatedTokenProgram.CreatedAssociatedAccount.toString|toString(){}[0]
+        }
+    }
+
+    sealed class SystemProgram : net.avianlabs.solana.domain.core/DecodedInstruction { // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram|null[0]
+        final val programIndex // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.programIndex|{}programIndex[0]
+            final fun <get-programIndex>(): kotlin/UInt // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.programIndex.<get-programIndex>|<get-programIndex>(){}[0]
+
+        final class AdvanceNonceAccount : net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+            final val authorizedPubkey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.authorizedPubkey|{}authorizedPubkey[0]
+                final fun <get-authorizedPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.authorizedPubkey.<get-authorizedPubkey>|<get-authorizedPubkey>(){}[0]
+            final val nonceAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.nonceAccount|{}nonceAccount[0]
+                final fun <get-nonceAccount>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.nonceAccount.<get-nonceAccount>|<get-nonceAccount>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.component2|component2(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AdvanceNonceAccount.toString|toString(){}[0]
+        }
+
+        final class AuthorizeNonceAccount : net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+            final val authorizedPubkey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.authorizedPubkey|{}authorizedPubkey[0]
+                final fun <get-authorizedPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.authorizedPubkey.<get-authorizedPubkey>|<get-authorizedPubkey>(){}[0]
+            final val newAuthorizedPubkey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.newAuthorizedPubkey|{}newAuthorizedPubkey[0]
+                final fun <get-newAuthorizedPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.newAuthorizedPubkey.<get-newAuthorizedPubkey>|<get-newAuthorizedPubkey>(){}[0]
+            final val nonceAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.nonceAccount|{}nonceAccount[0]
+                final fun <get-nonceAccount>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.nonceAccount.<get-nonceAccount>|<get-nonceAccount>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.component2|component2(){}[0]
+            final fun component3(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.component3|component3(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.AuthorizeNonceAccount.toString|toString(){}[0]
+        }
+
+        final class CreateAccount : net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Long, kotlin/Long, net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long;kotlin.Long;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+            final val from // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.from|{}from[0]
+                final fun <get-from>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.from.<get-from>|<get-from>(){}[0]
+            final val lamports // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.lamports|{}lamports[0]
+                final fun <get-lamports>(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.lamports.<get-lamports>|<get-lamports>(){}[0]
+            final val newAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.newAccount|{}newAccount[0]
+                final fun <get-newAccount>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.newAccount.<get-newAccount>|<get-newAccount>(){}[0]
+            final val owner // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.owner|{}owner[0]
+                final fun <get-owner>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.owner.<get-owner>|<get-owner>(){}[0]
+            final val space // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.space|{}space[0]
+                final fun <get-space>(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.space.<get-space>|<get-space>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.component2|component2(){}[0]
+            final fun component3(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.component3|component3(){}[0]
+            final fun component4(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.component4|component4(){}[0]
+            final fun component5(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.component5|component5(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/Long = ..., kotlin/Long = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long;kotlin.Long;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.CreateAccount.toString|toString(){}[0]
+        }
+
+        final class InitializeNonceAccount : net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+            final val authorizedPubkey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.authorizedPubkey|{}authorizedPubkey[0]
+                final fun <get-authorizedPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.authorizedPubkey.<get-authorizedPubkey>|<get-authorizedPubkey>(){}[0]
+            final val nonceAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.nonceAccount|{}nonceAccount[0]
+                final fun <get-nonceAccount>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.nonceAccount.<get-nonceAccount>|<get-nonceAccount>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.component2|component2(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.InitializeNonceAccount.toString|toString(){}[0]
+        }
+
+        final class Transfer : net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Long) // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long){}[0]
+
+            final val from // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.from|{}from[0]
+                final fun <get-from>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.from.<get-from>|<get-from>(){}[0]
+            final val lamports // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.lamports|{}lamports[0]
+                final fun <get-lamports>(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.lamports.<get-lamports>|<get-lamports>(){}[0]
+            final val to // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.to|{}to[0]
+                final fun <get-to>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.to.<get-to>|<get-to>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.component2|component2(){}[0]
+            final fun component3(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.component3|component3(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/Long = ...): net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.Transfer.toString|toString(){}[0]
+        }
+
+        final class WithdrawNonceAccount : net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Long) // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long){}[0]
+
+            final val authorizedPubkey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.authorizedPubkey|{}authorizedPubkey[0]
+                final fun <get-authorizedPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.authorizedPubkey.<get-authorizedPubkey>|<get-authorizedPubkey>(){}[0]
+            final val destination // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.destination|{}destination[0]
+                final fun <get-destination>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.destination.<get-destination>|<get-destination>(){}[0]
+            final val lamports // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.lamports|{}lamports[0]
+                final fun <get-lamports>(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.lamports.<get-lamports>|<get-lamports>(){}[0]
+            final val nonceAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.nonceAccount|{}nonceAccount[0]
+                final fun <get-nonceAccount>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.nonceAccount.<get-nonceAccount>|<get-nonceAccount>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.component2|component2(){}[0]
+            final fun component3(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.component3|component3(){}[0]
+            final fun component4(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.component4|component4(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/Long = ...): net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.SystemProgram.WithdrawNonceAccount.toString|toString(){}[0]
+        }
+    }
+
+    sealed class TokenProgram : net.avianlabs.solana.domain.core/DecodedInstruction { // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram|null[0]
+        final val programIndex // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.programIndex|{}programIndex[0]
+            final fun <get-programIndex>(): kotlin/UByte // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.programIndex.<get-programIndex>|<get-programIndex>(){}[0]
+
+        final class Transfer : net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Long) // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long){}[0]
+
+            final val amount // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.amount|{}amount[0]
+                final fun <get-amount>(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.amount.<get-amount>|<get-amount>(){}[0]
+            final val destination // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.destination|{}destination[0]
+                final fun <get-destination>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.destination.<get-destination>|<get-destination>(){}[0]
+            final val owner // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.owner|{}owner[0]
+                final fun <get-owner>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.owner.<get-owner>|<get-owner>(){}[0]
+            final val source // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.source|{}source[0]
+                final fun <get-source>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.source.<get-source>|<get-source>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.component2|component2(){}[0]
+            final fun component3(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.component3|component3(){}[0]
+            final fun component4(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.component4|component4(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/Long = ...): net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.Transfer.toString|toString(){}[0]
+        }
+
+        final class TransferChecked : net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram { // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Long, kotlin/UByte) // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long;kotlin.UByte){}[0]
+
+            final val amount // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.amount|{}amount[0]
+                final fun <get-amount>(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.amount.<get-amount>|<get-amount>(){}[0]
+            final val decimals // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.decimals|{}decimals[0]
+                final fun <get-decimals>(): kotlin/UByte // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.decimals.<get-decimals>|<get-decimals>(){}[0]
+            final val destination // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.destination|{}destination[0]
+                final fun <get-destination>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.destination.<get-destination>|<get-destination>(){}[0]
+            final val mint // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.mint|{}mint[0]
+                final fun <get-mint>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.mint.<get-mint>|<get-mint>(){}[0]
+            final val owner // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.owner|{}owner[0]
+                final fun <get-owner>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.owner.<get-owner>|<get-owner>(){}[0]
+            final val source // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.source|{}source[0]
+                final fun <get-source>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.source.<get-source>|<get-source>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.component2|component2(){}[0]
+            final fun component3(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.component3|component3(){}[0]
+            final fun component4(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.component4|component4(){}[0]
+            final fun component5(): kotlin/Long // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.component5|component5(){}[0]
+            final fun component6(): kotlin/UByte // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.component6|component6(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/Long = ..., kotlin/UByte = ...): net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long;kotlin.UByte){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/DecodedInstruction.TokenProgram.TransferChecked.toString|toString(){}[0]
+        }
+    }
+}
+
+sealed class net.avianlabs.solana.domain.core/VersionedMessage { // net.avianlabs.solana.domain.core/VersionedMessage|null[0]
+    abstract val feePayer // net.avianlabs.solana.domain.core/VersionedMessage.feePayer|{}feePayer[0]
+        abstract fun <get-feePayer>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.core/VersionedMessage.feePayer.<get-feePayer>|<get-feePayer>(){}[0]
+    abstract val instructions // net.avianlabs.solana.domain.core/VersionedMessage.instructions|{}instructions[0]
+        abstract fun <get-instructions>(): kotlin.collections/List<net.avianlabs.solana.domain.core/TransactionInstruction> // net.avianlabs.solana.domain.core/VersionedMessage.instructions.<get-instructions>|<get-instructions>(){}[0]
+    abstract val recentBlockHash // net.avianlabs.solana.domain.core/VersionedMessage.recentBlockHash|{}recentBlockHash[0]
+        abstract fun <get-recentBlockHash>(): kotlin/String? // net.avianlabs.solana.domain.core/VersionedMessage.recentBlockHash.<get-recentBlockHash>|<get-recentBlockHash>(){}[0]
+    abstract val staticAccountKeys // net.avianlabs.solana.domain.core/VersionedMessage.staticAccountKeys|{}staticAccountKeys[0]
+        abstract fun <get-staticAccountKeys>(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> // net.avianlabs.solana.domain.core/VersionedMessage.staticAccountKeys.<get-staticAccountKeys>|<get-staticAccountKeys>(){}[0]
+
+    final class Legacy : net.avianlabs.solana.domain.core/VersionedMessage { // net.avianlabs.solana.domain.core/VersionedMessage.Legacy|null[0]
+        constructor <init>(net.avianlabs.solana.domain.core/Message) // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.<init>|<init>(net.avianlabs.solana.domain.core.Message){}[0]
+
+        final val feePayer // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.feePayer|{}feePayer[0]
+            final fun <get-feePayer>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.feePayer.<get-feePayer>|<get-feePayer>(){}[0]
+        final val instructions // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.instructions|{}instructions[0]
+            final fun <get-instructions>(): kotlin.collections/List<net.avianlabs.solana.domain.core/TransactionInstruction> // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.instructions.<get-instructions>|<get-instructions>(){}[0]
+        final val message // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.message|{}message[0]
+            final fun <get-message>(): net.avianlabs.solana.domain.core/Message // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.message.<get-message>|<get-message>(){}[0]
+        final val recentBlockHash // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.recentBlockHash|{}recentBlockHash[0]
+            final fun <get-recentBlockHash>(): kotlin/String? // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.recentBlockHash.<get-recentBlockHash>|<get-recentBlockHash>(){}[0]
+        final val staticAccountKeys // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.staticAccountKeys|{}staticAccountKeys[0]
+            final fun <get-staticAccountKeys>(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.staticAccountKeys.<get-staticAccountKeys>|<get-staticAccountKeys>(){}[0]
+
+        final fun component1(): net.avianlabs.solana.domain.core/Message // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.component1|component1(){}[0]
+        final fun copy(net.avianlabs.solana.domain.core/Message = ...): net.avianlabs.solana.domain.core/VersionedMessage.Legacy // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.copy|copy(net.avianlabs.solana.domain.core.Message){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/VersionedMessage.Legacy.toString|toString(){}[0]
+    }
+
+    final class V0 : net.avianlabs.solana.domain.core/VersionedMessage { // net.avianlabs.solana.domain.core/VersionedMessage.V0|null[0]
+        constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, kotlin/String?, kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta>, kotlin.collections/List<net.avianlabs.solana.domain.core/TransactionInstruction>, kotlin.collections/List<net.avianlabs.solana.domain.core/MessageAddressTableLookup>, kotlin.collections/List<net.avianlabs.solana.domain.core/AddressLookupTableAccount> = ...) // net.avianlabs.solana.domain.core/VersionedMessage.V0.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.String?;kotlin.collections.List<net.avianlabs.solana.domain.core.AccountMeta>;kotlin.collections.List<net.avianlabs.solana.domain.core.TransactionInstruction>;kotlin.collections.List<net.avianlabs.solana.domain.core.MessageAddressTableLookup>;kotlin.collections.List<net.avianlabs.solana.domain.core.AddressLookupTableAccount>){}[0]
+
+        final val addressTableLookups // net.avianlabs.solana.domain.core/VersionedMessage.V0.addressTableLookups|{}addressTableLookups[0]
+            final fun <get-addressTableLookups>(): kotlin.collections/List<net.avianlabs.solana.domain.core/MessageAddressTableLookup> // net.avianlabs.solana.domain.core/VersionedMessage.V0.addressTableLookups.<get-addressTableLookups>|<get-addressTableLookups>(){}[0]
+        final val feePayer // net.avianlabs.solana.domain.core/VersionedMessage.V0.feePayer|{}feePayer[0]
+            final fun <get-feePayer>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.core/VersionedMessage.V0.feePayer.<get-feePayer>|<get-feePayer>(){}[0]
+        final val instructions // net.avianlabs.solana.domain.core/VersionedMessage.V0.instructions|{}instructions[0]
+            final fun <get-instructions>(): kotlin.collections/List<net.avianlabs.solana.domain.core/TransactionInstruction> // net.avianlabs.solana.domain.core/VersionedMessage.V0.instructions.<get-instructions>|<get-instructions>(){}[0]
+        final val recentBlockHash // net.avianlabs.solana.domain.core/VersionedMessage.V0.recentBlockHash|{}recentBlockHash[0]
+            final fun <get-recentBlockHash>(): kotlin/String? // net.avianlabs.solana.domain.core/VersionedMessage.V0.recentBlockHash.<get-recentBlockHash>|<get-recentBlockHash>(){}[0]
+        final val staticAccountKeys // net.avianlabs.solana.domain.core/VersionedMessage.V0.staticAccountKeys|{}staticAccountKeys[0]
+            final fun <get-staticAccountKeys>(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> // net.avianlabs.solana.domain.core/VersionedMessage.V0.staticAccountKeys.<get-staticAccountKeys>|<get-staticAccountKeys>(){}[0]
+
+        final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.core/VersionedMessage.V0.component1|component1(){}[0]
+        final fun component2(): kotlin/String? // net.avianlabs.solana.domain.core/VersionedMessage.V0.component2|component2(){}[0]
+        final fun component3(): kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> // net.avianlabs.solana.domain.core/VersionedMessage.V0.component3|component3(){}[0]
+        final fun component4(): kotlin.collections/List<net.avianlabs.solana.domain.core/TransactionInstruction> // net.avianlabs.solana.domain.core/VersionedMessage.V0.component4|component4(){}[0]
+        final fun component5(): kotlin.collections/List<net.avianlabs.solana.domain.core/MessageAddressTableLookup> // net.avianlabs.solana.domain.core/VersionedMessage.V0.component5|component5(){}[0]
+        final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., kotlin/String? = ..., kotlin.collections/List<net.avianlabs.solana.domain.core/AccountMeta> = ..., kotlin.collections/List<net.avianlabs.solana.domain.core/TransactionInstruction> = ..., kotlin.collections/List<net.avianlabs.solana.domain.core/MessageAddressTableLookup> = ..., kotlin.collections/List<net.avianlabs.solana.domain.core/AddressLookupTableAccount> = ...): net.avianlabs.solana.domain.core/VersionedMessage.V0 // net.avianlabs.solana.domain.core/VersionedMessage.V0.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.String?;kotlin.collections.List<net.avianlabs.solana.domain.core.AccountMeta>;kotlin.collections.List<net.avianlabs.solana.domain.core.TransactionInstruction>;kotlin.collections.List<net.avianlabs.solana.domain.core.MessageAddressTableLookup>;kotlin.collections.List<net.avianlabs.solana.domain.core.AddressLookupTableAccount>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.core/VersionedMessage.V0.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/VersionedMessage.V0.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/VersionedMessage.V0.toString|toString(){}[0]
+    }
+
+    final object Companion // net.avianlabs.solana.domain.core/VersionedMessage.Companion|null[0]
+}
+
+sealed class net.avianlabs.solana.domain.program/TokenProgram : net.avianlabs.solana.domain.program/Program { // net.avianlabs.solana.domain.program/TokenProgram|null[0]
+    abstract fun amountToUiAmount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.amountToUiAmount|amountToUiAmount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    abstract fun approve(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.approve|approve(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    abstract fun approveChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.approveChecked|approveChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    abstract fun burn(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.burn|burn(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    abstract fun burnChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.burnChecked|burnChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    abstract fun closeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.closeAccount|closeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun freezeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.freezeAccount|freezeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun getAccountDataSize(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.getAccountDataSize|getAccountDataSize(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun initializeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.initializeAccount|initializeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun initializeAccount2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.initializeAccount2|initializeAccount2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun initializeAccount3(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.initializeAccount3|initializeAccount3(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun initializeImmutableOwner(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.initializeImmutableOwner|initializeImmutableOwner(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun initializeMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.initializeMint|initializeMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun initializeMint2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.initializeMint2|initializeMint2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    abstract fun initializeMultisig(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.initializeMultisig|initializeMultisig(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun initializeMultisig2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.initializeMultisig2|initializeMultisig2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte){}[0]
+    abstract fun mintTo(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.mintTo|mintTo(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    abstract fun mintToChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.mintToChecked|mintToChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    abstract fun revoke(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.revoke|revoke(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun setAuthority(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/TokenProgram.AuthorityType, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.setAuthority|setAuthority(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.TokenProgram.AuthorityType;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    abstract fun syncNative(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.syncNative|syncNative(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun thawAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.thawAccount|thawAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    abstract fun transfer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.transfer|transfer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    abstract fun transferChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.transferChecked|transferChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    abstract fun uiAmountToAmount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.uiAmountToAmount|uiAmountToAmount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String){}[0]
+
+    final enum class AccountState : kotlin/Enum<net.avianlabs.solana.domain.program/TokenProgram.AccountState> { // net.avianlabs.solana.domain.program/TokenProgram.AccountState|null[0]
+        enum entry Frozen // net.avianlabs.solana.domain.program/TokenProgram.AccountState.Frozen|null[0]
+        enum entry Initialized // net.avianlabs.solana.domain.program/TokenProgram.AccountState.Initialized|null[0]
+        enum entry Uninitialized // net.avianlabs.solana.domain.program/TokenProgram.AccountState.Uninitialized|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/TokenProgram.AccountState.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/TokenProgram.AccountState> // net.avianlabs.solana.domain.program/TokenProgram.AccountState.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val value // net.avianlabs.solana.domain.program/TokenProgram.AccountState.value|{}value[0]
+            final fun <get-value>(): kotlin/UByte // net.avianlabs.solana.domain.program/TokenProgram.AccountState.value.<get-value>|<get-value>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/TokenProgram.AccountState // net.avianlabs.solana.domain.program/TokenProgram.AccountState.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/TokenProgram.AccountState> // net.avianlabs.solana.domain.program/TokenProgram.AccountState.values|values#static(){}[0]
+    }
+
+    final enum class AuthorityType : kotlin/Enum<net.avianlabs.solana.domain.program/TokenProgram.AuthorityType> { // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType|null[0]
+        enum entry AccountOwner // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.AccountOwner|null[0]
+        enum entry CloseAccount // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.CloseAccount|null[0]
+        enum entry CloseMint // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.CloseMint|null[0]
+        enum entry ConfidentialTransferFeeConfig // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.ConfidentialTransferFeeConfig|null[0]
+        enum entry ConfidentialTransferMint // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.ConfidentialTransferMint|null[0]
+        enum entry FreezeAccount // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.FreezeAccount|null[0]
+        enum entry GroupMemberPointer // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.GroupMemberPointer|null[0]
+        enum entry GroupPointer // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.GroupPointer|null[0]
+        enum entry InterestRate // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.InterestRate|null[0]
+        enum entry MetadataPointer // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.MetadataPointer|null[0]
+        enum entry MintTokens // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.MintTokens|null[0]
+        enum entry Pause // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.Pause|null[0]
+        enum entry PermanentDelegate // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.PermanentDelegate|null[0]
+        enum entry ScaledUiAmount // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.ScaledUiAmount|null[0]
+        enum entry TransferFeeConfig // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.TransferFeeConfig|null[0]
+        enum entry TransferHookProgramId // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.TransferHookProgramId|null[0]
+        enum entry WithheldWithdraw // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.WithheldWithdraw|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/TokenProgram.AuthorityType> // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val value // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.value|{}value[0]
+            final fun <get-value>(): kotlin/UByte // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.value.<get-value>|<get-value>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/TokenProgram.AuthorityType // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/TokenProgram.AuthorityType> // net.avianlabs.solana.domain.program/TokenProgram.AuthorityType.values|values#static(){}[0]
+    }
+
+    final enum class Instruction : kotlin/Enum<net.avianlabs.solana.domain.program/TokenProgram.Instruction> { // net.avianlabs.solana.domain.program/TokenProgram.Instruction|null[0]
+        enum entry AmountToUiAmount // net.avianlabs.solana.domain.program/TokenProgram.Instruction.AmountToUiAmount|null[0]
+        enum entry Approve // net.avianlabs.solana.domain.program/TokenProgram.Instruction.Approve|null[0]
+        enum entry ApproveChecked // net.avianlabs.solana.domain.program/TokenProgram.Instruction.ApproveChecked|null[0]
+        enum entry Burn // net.avianlabs.solana.domain.program/TokenProgram.Instruction.Burn|null[0]
+        enum entry BurnChecked // net.avianlabs.solana.domain.program/TokenProgram.Instruction.BurnChecked|null[0]
+        enum entry CloseAccount // net.avianlabs.solana.domain.program/TokenProgram.Instruction.CloseAccount|null[0]
+        enum entry FreezeAccount // net.avianlabs.solana.domain.program/TokenProgram.Instruction.FreezeAccount|null[0]
+        enum entry GetAccountDataSize // net.avianlabs.solana.domain.program/TokenProgram.Instruction.GetAccountDataSize|null[0]
+        enum entry InitializeAccount // net.avianlabs.solana.domain.program/TokenProgram.Instruction.InitializeAccount|null[0]
+        enum entry InitializeAccount2 // net.avianlabs.solana.domain.program/TokenProgram.Instruction.InitializeAccount2|null[0]
+        enum entry InitializeAccount3 // net.avianlabs.solana.domain.program/TokenProgram.Instruction.InitializeAccount3|null[0]
+        enum entry InitializeImmutableOwner // net.avianlabs.solana.domain.program/TokenProgram.Instruction.InitializeImmutableOwner|null[0]
+        enum entry InitializeMint // net.avianlabs.solana.domain.program/TokenProgram.Instruction.InitializeMint|null[0]
+        enum entry InitializeMint2 // net.avianlabs.solana.domain.program/TokenProgram.Instruction.InitializeMint2|null[0]
+        enum entry InitializeMultisig // net.avianlabs.solana.domain.program/TokenProgram.Instruction.InitializeMultisig|null[0]
+        enum entry InitializeMultisig2 // net.avianlabs.solana.domain.program/TokenProgram.Instruction.InitializeMultisig2|null[0]
+        enum entry MintTo // net.avianlabs.solana.domain.program/TokenProgram.Instruction.MintTo|null[0]
+        enum entry MintToChecked // net.avianlabs.solana.domain.program/TokenProgram.Instruction.MintToChecked|null[0]
+        enum entry Revoke // net.avianlabs.solana.domain.program/TokenProgram.Instruction.Revoke|null[0]
+        enum entry SetAuthority // net.avianlabs.solana.domain.program/TokenProgram.Instruction.SetAuthority|null[0]
+        enum entry SyncNative // net.avianlabs.solana.domain.program/TokenProgram.Instruction.SyncNative|null[0]
+        enum entry ThawAccount // net.avianlabs.solana.domain.program/TokenProgram.Instruction.ThawAccount|null[0]
+        enum entry Transfer // net.avianlabs.solana.domain.program/TokenProgram.Instruction.Transfer|null[0]
+        enum entry TransferChecked // net.avianlabs.solana.domain.program/TokenProgram.Instruction.TransferChecked|null[0]
+        enum entry UiAmountToAmount // net.avianlabs.solana.domain.program/TokenProgram.Instruction.UiAmountToAmount|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/TokenProgram.Instruction.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/TokenProgram.Instruction> // net.avianlabs.solana.domain.program/TokenProgram.Instruction.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val index // net.avianlabs.solana.domain.program/TokenProgram.Instruction.index|{}index[0]
+            final fun <get-index>(): kotlin/UByte // net.avianlabs.solana.domain.program/TokenProgram.Instruction.index.<get-index>|<get-index>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/TokenProgram.Instruction // net.avianlabs.solana.domain.program/TokenProgram.Instruction.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/TokenProgram.Instruction> // net.avianlabs.solana.domain.program/TokenProgram.Instruction.values|values#static(){}[0]
+    }
+
+    final object Companion : net.avianlabs.solana.domain.program/TokenProgram { // net.avianlabs.solana.domain.program/TokenProgram.Companion|null[0]
+        final val MINT_LENGTH // net.avianlabs.solana.domain.program/TokenProgram.Companion.MINT_LENGTH|{}MINT_LENGTH[0]
+            final fun <get-MINT_LENGTH>(): kotlin/Long // net.avianlabs.solana.domain.program/TokenProgram.Companion.MINT_LENGTH.<get-MINT_LENGTH>|<get-MINT_LENGTH>(){}[0]
+        final val MULTISIG_LENGTH // net.avianlabs.solana.domain.program/TokenProgram.Companion.MULTISIG_LENGTH|{}MULTISIG_LENGTH[0]
+            final fun <get-MULTISIG_LENGTH>(): kotlin/Long // net.avianlabs.solana.domain.program/TokenProgram.Companion.MULTISIG_LENGTH.<get-MULTISIG_LENGTH>|<get-MULTISIG_LENGTH>(){}[0]
+        final val RENT // net.avianlabs.solana.domain.program/TokenProgram.Companion.RENT|{}RENT[0]
+            final fun <get-RENT>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/TokenProgram.Companion.RENT.<get-RENT>|<get-RENT>(){}[0]
+        final val TOKEN_LENGTH // net.avianlabs.solana.domain.program/TokenProgram.Companion.TOKEN_LENGTH|{}TOKEN_LENGTH[0]
+            final fun <get-TOKEN_LENGTH>(): kotlin/Long // net.avianlabs.solana.domain.program/TokenProgram.Companion.TOKEN_LENGTH.<get-TOKEN_LENGTH>|<get-TOKEN_LENGTH>(){}[0]
+        final val programId // net.avianlabs.solana.domain.program/TokenProgram.Companion.programId|{}programId[0]
+            final fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/TokenProgram.Companion.programId.<get-programId>|<get-programId>(){}[0]
+
+        final fun amountToUiAmount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.amountToUiAmount|amountToUiAmount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+        final fun approve(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.approve|approve(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+        final fun approveChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.approveChecked|approveChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+        final fun burn(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.burn|burn(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+        final fun burnChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.burnChecked|burnChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+        final fun closeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.closeAccount|closeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun freezeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.freezeAccount|freezeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun getAccountDataSize(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.getAccountDataSize|getAccountDataSize(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun initializeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.initializeAccount|initializeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun initializeAccount2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.initializeAccount2|initializeAccount2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun initializeAccount3(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.initializeAccount3|initializeAccount3(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun initializeImmutableOwner(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.initializeImmutableOwner|initializeImmutableOwner(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun initializeMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.initializeMint|initializeMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun initializeMint2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.initializeMint2|initializeMint2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+        final fun initializeMultisig(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.initializeMultisig|initializeMultisig(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun initializeMultisig2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.initializeMultisig2|initializeMultisig2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte){}[0]
+        final fun mintTo(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.mintTo|mintTo(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+        final fun mintToChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.mintToChecked|mintToChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+        final fun revoke(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.revoke|revoke(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun setAuthority(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/TokenProgram.AuthorityType, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.setAuthority|setAuthority(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.TokenProgram.AuthorityType;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+        final fun syncNative(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.syncNative|syncNative(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun thawAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.thawAccount|thawAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+        final fun transfer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.transfer|transfer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+        final fun transferChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.transferChecked|transferChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+        final fun uiAmountToAmount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/TokenProgram.Companion.uiAmountToAmount|uiAmountToAmount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String){}[0]
+    }
+}
+
+final object net.avianlabs.solana.domain.program/AssociatedTokenProgram : net.avianlabs.solana.domain.program/Program { // net.avianlabs.solana.domain.program/AssociatedTokenProgram|null[0]
+    final val programId // net.avianlabs.solana.domain.program/AssociatedTokenProgram.programId|{}programId[0]
+        final fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/AssociatedTokenProgram.programId.<get-programId>|<get-programId>(){}[0]
+
+    final fun createAssociatedToken(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/AssociatedTokenProgram.createAssociatedToken|createAssociatedToken(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun createAssociatedTokenAccountInstruction(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/AssociatedTokenProgram.createAssociatedTokenAccountInstruction|createAssociatedTokenAccountInstruction(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun createAssociatedTokenAccountInstructionIdempotent(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/AssociatedTokenProgram.createAssociatedTokenAccountInstructionIdempotent|createAssociatedTokenAccountInstructionIdempotent(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun createAssociatedTokenIdempotent(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/AssociatedTokenProgram.createAssociatedTokenIdempotent|createAssociatedTokenIdempotent(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun recoverNestedAssociatedToken(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/AssociatedTokenProgram.recoverNestedAssociatedToken|recoverNestedAssociatedToken(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+    final enum class Instruction : kotlin/Enum<net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction> { // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction|null[0]
+        enum entry CreateAssociatedToken // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.CreateAssociatedToken|null[0]
+        enum entry CreateAssociatedTokenIdempotent // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.CreateAssociatedTokenIdempotent|null[0]
+        enum entry RecoverNestedAssociatedToken // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.RecoverNestedAssociatedToken|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction> // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val index // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.index|{}index[0]
+            final fun <get-index>(): kotlin/UByte // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.index.<get-index>|<get-index>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction> // net.avianlabs.solana.domain.program/AssociatedTokenProgram.Instruction.values|values#static(){}[0]
+    }
+}
+
+final object net.avianlabs.solana.domain.program/ComputeBudgetProgram : net.avianlabs.solana.domain.program/Program { // net.avianlabs.solana.domain.program/ComputeBudgetProgram|null[0]
+    final val programId // net.avianlabs.solana.domain.program/ComputeBudgetProgram.programId|{}programId[0]
+        final fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/ComputeBudgetProgram.programId.<get-programId>|<get-programId>(){}[0]
+
+    final fun requestHeapFrame(kotlin/UInt): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/ComputeBudgetProgram.requestHeapFrame|requestHeapFrame(kotlin.UInt){}[0]
+    final fun requestUnits(kotlin/UInt, kotlin/UInt): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/ComputeBudgetProgram.requestUnits|requestUnits(kotlin.UInt;kotlin.UInt){}[0]
+    final fun setComputeUnitLimit(kotlin/UInt): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/ComputeBudgetProgram.setComputeUnitLimit|setComputeUnitLimit(kotlin.UInt){}[0]
+    final fun setComputeUnitPrice(kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/ComputeBudgetProgram.setComputeUnitPrice|setComputeUnitPrice(kotlin.ULong){}[0]
+    final fun setLoadedAccountsDataSizeLimit(kotlin/UInt): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/ComputeBudgetProgram.setLoadedAccountsDataSizeLimit|setLoadedAccountsDataSizeLimit(kotlin.UInt){}[0]
+
+    final enum class Instruction : kotlin/Enum<net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction> { // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction|null[0]
+        enum entry RequestHeapFrame // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.RequestHeapFrame|null[0]
+        enum entry RequestUnits // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.RequestUnits|null[0]
+        enum entry SetComputeUnitLimit // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.SetComputeUnitLimit|null[0]
+        enum entry SetComputeUnitPrice // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.SetComputeUnitPrice|null[0]
+        enum entry SetLoadedAccountsDataSizeLimit // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.SetLoadedAccountsDataSizeLimit|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction> // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val index // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.index|{}index[0]
+            final fun <get-index>(): kotlin/UByte // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.index.<get-index>|<get-index>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction> // net.avianlabs.solana.domain.program/ComputeBudgetProgram.Instruction.values|values#static(){}[0]
+    }
+}
+
+final object net.avianlabs.solana.domain.program/SystemProgram : net.avianlabs.solana.domain.program/Program { // net.avianlabs.solana.domain.program/SystemProgram|null[0]
+    final val NONCE_ACCOUNT_LENGTH // net.avianlabs.solana.domain.program/SystemProgram.NONCE_ACCOUNT_LENGTH|{}NONCE_ACCOUNT_LENGTH[0]
+        final fun <get-NONCE_ACCOUNT_LENGTH>(): kotlin/Long // net.avianlabs.solana.domain.program/SystemProgram.NONCE_ACCOUNT_LENGTH.<get-NONCE_ACCOUNT_LENGTH>|<get-NONCE_ACCOUNT_LENGTH>(){}[0]
+    final val NONCE_LENGTH // net.avianlabs.solana.domain.program/SystemProgram.NONCE_LENGTH|{}NONCE_LENGTH[0]
+        final fun <get-NONCE_LENGTH>(): kotlin/Long // net.avianlabs.solana.domain.program/SystemProgram.NONCE_LENGTH.<get-NONCE_LENGTH>|<get-NONCE_LENGTH>(){}[0]
+    final val RECENT_BLOCKHASHES_SYSVAR // net.avianlabs.solana.domain.program/SystemProgram.RECENT_BLOCKHASHES_SYSVAR|{}RECENT_BLOCKHASHES_SYSVAR[0]
+        final fun <get-RECENT_BLOCKHASHES_SYSVAR>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/SystemProgram.RECENT_BLOCKHASHES_SYSVAR.<get-RECENT_BLOCKHASHES_SYSVAR>|<get-RECENT_BLOCKHASHES_SYSVAR>(){}[0]
+    final val RENT_SYSVAR // net.avianlabs.solana.domain.program/SystemProgram.RENT_SYSVAR|{}RENT_SYSVAR[0]
+        final fun <get-RENT_SYSVAR>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/SystemProgram.RENT_SYSVAR.<get-RENT_SYSVAR>|<get-RENT_SYSVAR>(){}[0]
+    final val SYSVAR_RECENT_BLOCKHASH // net.avianlabs.solana.domain.program/SystemProgram.SYSVAR_RECENT_BLOCKHASH|{}SYSVAR_RECENT_BLOCKHASH[0]
+        final fun <get-SYSVAR_RECENT_BLOCKHASH>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/SystemProgram.SYSVAR_RECENT_BLOCKHASH.<get-SYSVAR_RECENT_BLOCKHASH>|<get-SYSVAR_RECENT_BLOCKHASH>(){}[0]
+    final val SYSVAR_RENT_ACCOUNT // net.avianlabs.solana.domain.program/SystemProgram.SYSVAR_RENT_ACCOUNT|{}SYSVAR_RENT_ACCOUNT[0]
+        final fun <get-SYSVAR_RENT_ACCOUNT>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/SystemProgram.SYSVAR_RENT_ACCOUNT.<get-SYSVAR_RENT_ACCOUNT>|<get-SYSVAR_RENT_ACCOUNT>(){}[0]
+    final val programId // net.avianlabs.solana.domain.program/SystemProgram.programId|{}programId[0]
+        final fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/SystemProgram.programId.<get-programId>|<get-programId>(){}[0]
+
+    final fun advanceNonceAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.advanceNonceAccount|advanceNonceAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun allocate(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.allocate|allocate(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    final fun allocateWithSeed(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String, kotlin/ULong, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.allocateWithSeed|allocateWithSeed(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;kotlin.ULong;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun assign(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.assign|assign(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun assignWithSeed(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.assignWithSeed|assignWithSeed(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun authorizeNonceAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.authorizeNonceAccount|authorizeNonceAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun createAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/ULong, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.createAccount|createAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.ULong;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun createAccountWithSeed(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String, kotlin/ULong, kotlin/ULong, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.createAccountWithSeed|createAccountWithSeed(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;kotlin.ULong;kotlin.ULong;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeNonceAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.initializeNonceAccount|initializeNonceAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun nonceAdvance(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.nonceAdvance|nonceAdvance(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun nonceInitialize(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.nonceInitialize|nonceInitialize(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun transfer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Long): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.transfer|transfer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long){}[0]
+    final fun transferSol(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.transferSol|transferSol(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    final fun transferSolWithSeed(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/String, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.transferSolWithSeed|transferSolWithSeed(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.String;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun upgradeNonceAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.upgradeNonceAccount|upgradeNonceAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun withdrawNonceAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/SystemProgram.withdrawNonceAccount|withdrawNonceAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+    final enum class Instruction : kotlin/Enum<net.avianlabs.solana.domain.program/SystemProgram.Instruction> { // net.avianlabs.solana.domain.program/SystemProgram.Instruction|null[0]
+        enum entry AdvanceNonceAccount // net.avianlabs.solana.domain.program/SystemProgram.Instruction.AdvanceNonceAccount|null[0]
+        enum entry Allocate // net.avianlabs.solana.domain.program/SystemProgram.Instruction.Allocate|null[0]
+        enum entry AllocateWithSeed // net.avianlabs.solana.domain.program/SystemProgram.Instruction.AllocateWithSeed|null[0]
+        enum entry Assign // net.avianlabs.solana.domain.program/SystemProgram.Instruction.Assign|null[0]
+        enum entry AssignWithSeed // net.avianlabs.solana.domain.program/SystemProgram.Instruction.AssignWithSeed|null[0]
+        enum entry AuthorizeNonceAccount // net.avianlabs.solana.domain.program/SystemProgram.Instruction.AuthorizeNonceAccount|null[0]
+        enum entry CreateAccount // net.avianlabs.solana.domain.program/SystemProgram.Instruction.CreateAccount|null[0]
+        enum entry CreateAccountWithSeed // net.avianlabs.solana.domain.program/SystemProgram.Instruction.CreateAccountWithSeed|null[0]
+        enum entry InitializeNonceAccount // net.avianlabs.solana.domain.program/SystemProgram.Instruction.InitializeNonceAccount|null[0]
+        enum entry TransferSol // net.avianlabs.solana.domain.program/SystemProgram.Instruction.TransferSol|null[0]
+        enum entry TransferSolWithSeed // net.avianlabs.solana.domain.program/SystemProgram.Instruction.TransferSolWithSeed|null[0]
+        enum entry UpgradeNonceAccount // net.avianlabs.solana.domain.program/SystemProgram.Instruction.UpgradeNonceAccount|null[0]
+        enum entry WithdrawNonceAccount // net.avianlabs.solana.domain.program/SystemProgram.Instruction.WithdrawNonceAccount|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/SystemProgram.Instruction.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/SystemProgram.Instruction> // net.avianlabs.solana.domain.program/SystemProgram.Instruction.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val index // net.avianlabs.solana.domain.program/SystemProgram.Instruction.index|{}index[0]
+            final fun <get-index>(): kotlin/UInt // net.avianlabs.solana.domain.program/SystemProgram.Instruction.index.<get-index>|<get-index>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/SystemProgram.Instruction // net.avianlabs.solana.domain.program/SystemProgram.Instruction.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/SystemProgram.Instruction> // net.avianlabs.solana.domain.program/SystemProgram.Instruction.values|values#static(){}[0]
+    }
+
+    final enum class NonceState : kotlin/Enum<net.avianlabs.solana.domain.program/SystemProgram.NonceState> { // net.avianlabs.solana.domain.program/SystemProgram.NonceState|null[0]
+        enum entry Initialized // net.avianlabs.solana.domain.program/SystemProgram.NonceState.Initialized|null[0]
+        enum entry Uninitialized // net.avianlabs.solana.domain.program/SystemProgram.NonceState.Uninitialized|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/SystemProgram.NonceState.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/SystemProgram.NonceState> // net.avianlabs.solana.domain.program/SystemProgram.NonceState.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val value // net.avianlabs.solana.domain.program/SystemProgram.NonceState.value|{}value[0]
+            final fun <get-value>(): kotlin/UInt // net.avianlabs.solana.domain.program/SystemProgram.NonceState.value.<get-value>|<get-value>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/SystemProgram.NonceState // net.avianlabs.solana.domain.program/SystemProgram.NonceState.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/SystemProgram.NonceState> // net.avianlabs.solana.domain.program/SystemProgram.NonceState.values|values#static(){}[0]
+    }
+
+    final enum class NonceVersion : kotlin/Enum<net.avianlabs.solana.domain.program/SystemProgram.NonceVersion> { // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion|null[0]
+        enum entry Current // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion.Current|null[0]
+        enum entry Legacy // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion.Legacy|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/SystemProgram.NonceVersion> // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val value // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion.value|{}value[0]
+            final fun <get-value>(): kotlin/UInt // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion.value.<get-value>|<get-value>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/SystemProgram.NonceVersion // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/SystemProgram.NonceVersion> // net.avianlabs.solana.domain.program/SystemProgram.NonceVersion.values|values#static(){}[0]
+    }
+}
+
+final object net.avianlabs.solana.domain.program/Token2022Program : net.avianlabs.solana.domain.program/TokenProgram { // net.avianlabs.solana.domain.program/Token2022Program|null[0]
+    final val INSTRUCTIONS_SYSVAR_OR_CONTEXT_STATE // net.avianlabs.solana.domain.program/Token2022Program.INSTRUCTIONS_SYSVAR_OR_CONTEXT_STATE|{}INSTRUCTIONS_SYSVAR_OR_CONTEXT_STATE[0]
+        final fun <get-INSTRUCTIONS_SYSVAR_OR_CONTEXT_STATE>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.INSTRUCTIONS_SYSVAR_OR_CONTEXT_STATE.<get-INSTRUCTIONS_SYSVAR_OR_CONTEXT_STATE>|<get-INSTRUCTIONS_SYSVAR_OR_CONTEXT_STATE>(){}[0]
+    final val MULTISIG_LENGTH // net.avianlabs.solana.domain.program/Token2022Program.MULTISIG_LENGTH|{}MULTISIG_LENGTH[0]
+        final fun <get-MULTISIG_LENGTH>(): kotlin/Long // net.avianlabs.solana.domain.program/Token2022Program.MULTISIG_LENGTH.<get-MULTISIG_LENGTH>|<get-MULTISIG_LENGTH>(){}[0]
+    final val RENT // net.avianlabs.solana.domain.program/Token2022Program.RENT|{}RENT[0]
+        final fun <get-RENT>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.RENT.<get-RENT>|<get-RENT>(){}[0]
+    final val programId // net.avianlabs.solana.domain.program/Token2022Program.programId|{}programId[0]
+        final fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.programId.<get-programId>|<get-programId>(){}[0]
+
+    final fun amountToUiAmount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.amountToUiAmount|amountToUiAmount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    final fun applyConfidentialPendingBalance(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.applyConfidentialPendingBalance|applyConfidentialPendingBalance(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance){}[0]
+    final fun approve(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.approve|approve(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    final fun approveChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.approveChecked|approveChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    final fun approveConfidentialTransferAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.approveConfidentialTransferAccount|approveConfidentialTransferAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun burn(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.burn|burn(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    final fun burnChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.burnChecked|burnChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    final fun closeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.closeAccount|closeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun confidentialDeposit(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.confidentialDeposit|confidentialDeposit(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    final fun confidentialTransfer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance, kotlin/Byte, kotlin/Byte, kotlin/Byte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.confidentialTransfer|confidentialTransfer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance;kotlin.Byte;kotlin.Byte;kotlin.Byte){}[0]
+    final fun confidentialTransferWithFee(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance, kotlin/Byte, kotlin/Byte, kotlin/Byte, kotlin/Byte, kotlin/Byte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.confidentialTransferWithFee|confidentialTransferWithFee(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance;kotlin.Byte;kotlin.Byte;kotlin.Byte;kotlin.Byte;kotlin.Byte){}[0]
+    final fun confidentialWithdraw(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte, net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance, kotlin/Byte, kotlin/Byte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.confidentialWithdraw|confidentialWithdraw(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance;kotlin.Byte;kotlin.Byte){}[0]
+    final fun configureConfidentialTransferAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance, kotlin/ULong, kotlin/Byte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.configureConfidentialTransferAccount|configureConfidentialTransferAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance;kotlin.ULong;kotlin.Byte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun createNativeMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.createNativeMint|createNativeMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun disableConfidentialCredits(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.disableConfidentialCredits|disableConfidentialCredits(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun disableCpiGuard(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.disableCpiGuard|disableCpiGuard(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun disableHarvestToMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.disableHarvestToMint|disableHarvestToMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun disableMemoTransfers(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.disableMemoTransfers|disableMemoTransfers(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun disableNonConfidentialCredits(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.disableNonConfidentialCredits|disableNonConfidentialCredits(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun emitTokenMetadata(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong?, kotlin/ULong?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.emitTokenMetadata|emitTokenMetadata(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong?;kotlin.ULong?){}[0]
+    final fun emptyConfidentialTransferAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Byte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.emptyConfidentialTransferAccount|emptyConfidentialTransferAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Byte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun enableConfidentialCredits(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.enableConfidentialCredits|enableConfidentialCredits(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun enableCpiGuard(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.enableCpiGuard|enableCpiGuard(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun enableHarvestToMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.enableHarvestToMint|enableHarvestToMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun enableMemoTransfers(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.enableMemoTransfers|enableMemoTransfers(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun enableNonConfidentialCredits(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.enableNonConfidentialCredits|enableNonConfidentialCredits(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun freezeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.freezeAccount|freezeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun getAccountDataSize(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.getAccountDataSize|getAccountDataSize(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun harvestWithheldTokensToMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.harvestWithheldTokensToMint|harvestWithheldTokensToMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun harvestWithheldTokensToMintForConfidentialTransferFee(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.harvestWithheldTokensToMintForConfidentialTransferFee|harvestWithheldTokensToMintForConfidentialTransferFee(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeAccount|initializeAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeAccount2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeAccount2|initializeAccount2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeAccount3(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeAccount3|initializeAccount3(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeConfidentialTransferFee(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeConfidentialTransferFee|initializeConfidentialTransferFee(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun initializeConfidentialTransferMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, kotlin/Boolean, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeConfidentialTransferMint|initializeConfidentialTransferMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.Boolean;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun initializeDefaultAccountState(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/Token2022Program.AccountState): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeDefaultAccountState|initializeDefaultAccountState(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.Token2022Program.AccountState){}[0]
+    final fun initializeGroupMemberPointer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeGroupMemberPointer|initializeGroupMemberPointer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun initializeGroupPointer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeGroupPointer|initializeGroupPointer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun initializeImmutableOwner(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeImmutableOwner|initializeImmutableOwner(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeInterestBearingMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, kotlin/Short): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeInterestBearingMint|initializeInterestBearingMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.Short){}[0]
+    final fun initializeMetadataPointer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeMetadataPointer|initializeMetadataPointer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun initializeMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeMint|initializeMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeMint2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeMint2|initializeMint2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun initializeMintCloseAuthority(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeMintCloseAuthority|initializeMintCloseAuthority(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun initializeMultisig(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeMultisig|initializeMultisig(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeMultisig2(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeMultisig2|initializeMultisig2(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte){}[0]
+    final fun initializeNonTransferableMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeNonTransferableMint|initializeNonTransferableMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializePausableConfig(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializePausableConfig|initializePausableConfig(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun initializePermanentDelegate(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializePermanentDelegate|initializePermanentDelegate(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeScaledUiAmountMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, kotlin/Double): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeScaledUiAmountMint|initializeScaledUiAmountMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.Double){}[0]
+    final fun initializeTokenGroup(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeTokenGroup|initializeTokenGroup(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.ULong){}[0]
+    final fun initializeTokenGroupMember(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeTokenGroupMember|initializeTokenGroupMember(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun initializeTokenMetadata(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String, kotlin/String, kotlin/String): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeTokenMetadata|initializeTokenMetadata(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;kotlin.String;kotlin.String){}[0]
+    final fun initializeTransferFeeConfig(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, kotlin/UShort, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeTransferFeeConfig|initializeTransferFeeConfig(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.UShort;kotlin.ULong){}[0]
+    final fun initializeTransferHook(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.initializeTransferHook|initializeTransferHook(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun mintTo(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.mintTo|mintTo(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    final fun mintToChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.mintToChecked|mintToChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    final fun pause(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.pause|pause(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun reallocate(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin.collections/List<net.avianlabs.solana.domain.program/Token2022Program.ExtensionType>, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.reallocate|reallocate(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.collections.List<net.avianlabs.solana.domain.program.Token2022Program.ExtensionType>;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun removeTokenMetadataKey(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Boolean, kotlin/String): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.removeTokenMetadataKey|removeTokenMetadataKey(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Boolean;kotlin.String){}[0]
+    final fun resume(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.resume|resume(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun revoke(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.revoke|revoke(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun setAuthority(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/TokenProgram.AuthorityType, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.setAuthority|setAuthority(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.TokenProgram.AuthorityType;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun setTransferFee(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UShort, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.setTransferFee|setTransferFee(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UShort;kotlin.ULong){}[0]
+    final fun syncNative(net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.syncNative|syncNative(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun thawAccount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.thawAccount|thawAccount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun transfer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.transfer|transfer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    final fun transferChecked(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.transferChecked|transferChecked(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte){}[0]
+    final fun transferCheckedWithFee(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/UByte, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.transferCheckedWithFee|transferCheckedWithFee(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.UByte;kotlin.ULong){}[0]
+    final fun uiAmountToAmount(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.uiAmountToAmount|uiAmountToAmount(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String){}[0]
+    final fun unwrapLamports(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.unwrapLamports|unwrapLamports(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong?){}[0]
+    final fun updateConfidentialTransferMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Boolean, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateConfidentialTransferMint|updateConfidentialTransferMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Boolean;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun updateDefaultAccountState(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/Token2022Program.AccountState): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateDefaultAccountState|updateDefaultAccountState(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.Token2022Program.AccountState){}[0]
+    final fun updateGroupMemberPointer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateGroupMemberPointer|updateGroupMemberPointer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun updateGroupPointer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateGroupPointer|updateGroupPointer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun updateMetadataPointer(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateMetadataPointer|updateMetadataPointer(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun updateMultiplierScaledUiMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Double, kotlin/Long): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateMultiplierScaledUiMint|updateMultiplierScaledUiMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Double;kotlin.Long){}[0]
+    final fun updateRateInterestBearingMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Short): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateRateInterestBearingMint|updateRateInterestBearingMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Short){}[0]
+    final fun updateTokenGroupMaxSize(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateTokenGroupMaxSize|updateTokenGroupMaxSize(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+    final fun updateTokenGroupUpdateAuthority(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateTokenGroupUpdateAuthority|updateTokenGroupUpdateAuthority(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun updateTokenMetadataField(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField, kotlin/String): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateTokenMetadataField|updateTokenMetadataField(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.Token2022Program.TokenMetadataField;kotlin.String){}[0]
+    final fun updateTokenMetadataUpdateAuthority(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateTokenMetadataUpdateAuthority|updateTokenMetadataUpdateAuthority(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun updateTransferHook(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.updateTransferHook|updateTransferHook(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+    final fun withdrawExcessLamports(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.withdrawExcessLamports|withdrawExcessLamports(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun withdrawWithheldTokensFromAccounts(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.withdrawWithheldTokensFromAccounts|withdrawWithheldTokensFromAccounts(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte){}[0]
+    final fun withdrawWithheldTokensFromAccountsForConfidentialTransferFee(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/UByte, kotlin/Byte, net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.withdrawWithheldTokensFromAccountsForConfidentialTransferFee|withdrawWithheldTokensFromAccountsForConfidentialTransferFee(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.UByte;kotlin.Byte;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance){}[0]
+    final fun withdrawWithheldTokensFromMint(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.withdrawWithheldTokensFromMint|withdrawWithheldTokensFromMint(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+    final fun withdrawWithheldTokensFromMintForConfidentialTransferFee(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Byte, net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance): net.avianlabs.solana.domain.core/TransactionInstruction // net.avianlabs.solana.domain.program/Token2022Program.withdrawWithheldTokensFromMintForConfidentialTransferFee|withdrawWithheldTokensFromMintForConfidentialTransferFee(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Byte;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance){}[0]
+
+    final enum class AccountState : kotlin/Enum<net.avianlabs.solana.domain.program/Token2022Program.AccountState> { // net.avianlabs.solana.domain.program/Token2022Program.AccountState|null[0]
+        enum entry Frozen // net.avianlabs.solana.domain.program/Token2022Program.AccountState.Frozen|null[0]
+        enum entry Initialized // net.avianlabs.solana.domain.program/Token2022Program.AccountState.Initialized|null[0]
+        enum entry Uninitialized // net.avianlabs.solana.domain.program/Token2022Program.AccountState.Uninitialized|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/Token2022Program.AccountState.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/Token2022Program.AccountState> // net.avianlabs.solana.domain.program/Token2022Program.AccountState.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val value // net.avianlabs.solana.domain.program/Token2022Program.AccountState.value|{}value[0]
+            final fun <get-value>(): kotlin/UByte // net.avianlabs.solana.domain.program/Token2022Program.AccountState.value.<get-value>|<get-value>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/Token2022Program.AccountState // net.avianlabs.solana.domain.program/Token2022Program.AccountState.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/Token2022Program.AccountState> // net.avianlabs.solana.domain.program/Token2022Program.AccountState.values|values#static(){}[0]
+    }
+
+    final enum class AuthorityType : kotlin/Enum<net.avianlabs.solana.domain.program/Token2022Program.AuthorityType> { // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType|null[0]
+        enum entry AccountOwner // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.AccountOwner|null[0]
+        enum entry CloseAccount // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.CloseAccount|null[0]
+        enum entry CloseMint // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.CloseMint|null[0]
+        enum entry ConfidentialTransferFeeConfig // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.ConfidentialTransferFeeConfig|null[0]
+        enum entry ConfidentialTransferMint // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.ConfidentialTransferMint|null[0]
+        enum entry FreezeAccount // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.FreezeAccount|null[0]
+        enum entry GroupMemberPointer // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.GroupMemberPointer|null[0]
+        enum entry GroupPointer // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.GroupPointer|null[0]
+        enum entry InterestRate // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.InterestRate|null[0]
+        enum entry MetadataPointer // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.MetadataPointer|null[0]
+        enum entry MintTokens // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.MintTokens|null[0]
+        enum entry Pause // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.Pause|null[0]
+        enum entry PermanentDelegate // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.PermanentDelegate|null[0]
+        enum entry ScaledUiAmount // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.ScaledUiAmount|null[0]
+        enum entry TransferFeeConfig // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.TransferFeeConfig|null[0]
+        enum entry TransferHookProgramId // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.TransferHookProgramId|null[0]
+        enum entry WithheldWithdraw // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.WithheldWithdraw|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/Token2022Program.AuthorityType> // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val value // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.value|{}value[0]
+            final fun <get-value>(): kotlin/UByte // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.value.<get-value>|<get-value>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/Token2022Program.AuthorityType // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/Token2022Program.AuthorityType> // net.avianlabs.solana.domain.program/Token2022Program.AuthorityType.values|values#static(){}[0]
+    }
+
+    final enum class ExtensionType : kotlin/Enum<net.avianlabs.solana.domain.program/Token2022Program.ExtensionType> { // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType|null[0]
+        enum entry ConfidentialTransferAccount // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.ConfidentialTransferAccount|null[0]
+        enum entry ConfidentialTransferFee // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.ConfidentialTransferFee|null[0]
+        enum entry ConfidentialTransferFeeAmount // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.ConfidentialTransferFeeAmount|null[0]
+        enum entry ConfidentialTransferMint // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.ConfidentialTransferMint|null[0]
+        enum entry CpiGuard // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.CpiGuard|null[0]
+        enum entry DefaultAccountState // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.DefaultAccountState|null[0]
+        enum entry GroupMemberPointer // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.GroupMemberPointer|null[0]
+        enum entry GroupPointer // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.GroupPointer|null[0]
+        enum entry ImmutableOwner // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.ImmutableOwner|null[0]
+        enum entry InterestBearingConfig // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.InterestBearingConfig|null[0]
+        enum entry MemoTransfer // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.MemoTransfer|null[0]
+        enum entry MetadataPointer // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.MetadataPointer|null[0]
+        enum entry MintCloseAuthority // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.MintCloseAuthority|null[0]
+        enum entry NonTransferable // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.NonTransferable|null[0]
+        enum entry NonTransferableAccount // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.NonTransferableAccount|null[0]
+        enum entry PausableAccount // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.PausableAccount|null[0]
+        enum entry PausableConfig // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.PausableConfig|null[0]
+        enum entry PermanentDelegate // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.PermanentDelegate|null[0]
+        enum entry ScaledUiAmountConfig // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.ScaledUiAmountConfig|null[0]
+        enum entry TokenGroup // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.TokenGroup|null[0]
+        enum entry TokenGroupMember // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.TokenGroupMember|null[0]
+        enum entry TokenMetadata // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.TokenMetadata|null[0]
+        enum entry TransferFeeAmount // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.TransferFeeAmount|null[0]
+        enum entry TransferFeeConfig // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.TransferFeeConfig|null[0]
+        enum entry TransferHook // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.TransferHook|null[0]
+        enum entry TransferHookAccount // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.TransferHookAccount|null[0]
+        enum entry Uninitialized // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.Uninitialized|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/Token2022Program.ExtensionType> // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val value // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.value|{}value[0]
+            final fun <get-value>(): kotlin/UShort // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.value.<get-value>|<get-value>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/Token2022Program.ExtensionType // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/Token2022Program.ExtensionType> // net.avianlabs.solana.domain.program/Token2022Program.ExtensionType.values|values#static(){}[0]
+    }
+
+    final enum class Instruction : kotlin/Enum<net.avianlabs.solana.domain.program/Token2022Program.Instruction> { // net.avianlabs.solana.domain.program/Token2022Program.Instruction|null[0]
+        enum entry AmountToUiAmount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.AmountToUiAmount|null[0]
+        enum entry ApplyConfidentialPendingBalance // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ApplyConfidentialPendingBalance|null[0]
+        enum entry Approve // net.avianlabs.solana.domain.program/Token2022Program.Instruction.Approve|null[0]
+        enum entry ApproveChecked // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ApproveChecked|null[0]
+        enum entry ApproveConfidentialTransferAccount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ApproveConfidentialTransferAccount|null[0]
+        enum entry Burn // net.avianlabs.solana.domain.program/Token2022Program.Instruction.Burn|null[0]
+        enum entry BurnChecked // net.avianlabs.solana.domain.program/Token2022Program.Instruction.BurnChecked|null[0]
+        enum entry CloseAccount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.CloseAccount|null[0]
+        enum entry ConfidentialDeposit // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ConfidentialDeposit|null[0]
+        enum entry ConfidentialTransfer // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ConfidentialTransfer|null[0]
+        enum entry ConfidentialTransferWithFee // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ConfidentialTransferWithFee|null[0]
+        enum entry ConfidentialWithdraw // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ConfidentialWithdraw|null[0]
+        enum entry ConfigureConfidentialTransferAccount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ConfigureConfidentialTransferAccount|null[0]
+        enum entry CreateNativeMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.CreateNativeMint|null[0]
+        enum entry DisableConfidentialCredits // net.avianlabs.solana.domain.program/Token2022Program.Instruction.DisableConfidentialCredits|null[0]
+        enum entry DisableCpiGuard // net.avianlabs.solana.domain.program/Token2022Program.Instruction.DisableCpiGuard|null[0]
+        enum entry DisableHarvestToMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.DisableHarvestToMint|null[0]
+        enum entry DisableMemoTransfers // net.avianlabs.solana.domain.program/Token2022Program.Instruction.DisableMemoTransfers|null[0]
+        enum entry DisableNonConfidentialCredits // net.avianlabs.solana.domain.program/Token2022Program.Instruction.DisableNonConfidentialCredits|null[0]
+        enum entry EmptyConfidentialTransferAccount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.EmptyConfidentialTransferAccount|null[0]
+        enum entry EnableConfidentialCredits // net.avianlabs.solana.domain.program/Token2022Program.Instruction.EnableConfidentialCredits|null[0]
+        enum entry EnableCpiGuard // net.avianlabs.solana.domain.program/Token2022Program.Instruction.EnableCpiGuard|null[0]
+        enum entry EnableHarvestToMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.EnableHarvestToMint|null[0]
+        enum entry EnableMemoTransfers // net.avianlabs.solana.domain.program/Token2022Program.Instruction.EnableMemoTransfers|null[0]
+        enum entry EnableNonConfidentialCredits // net.avianlabs.solana.domain.program/Token2022Program.Instruction.EnableNonConfidentialCredits|null[0]
+        enum entry FreezeAccount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.FreezeAccount|null[0]
+        enum entry GetAccountDataSize // net.avianlabs.solana.domain.program/Token2022Program.Instruction.GetAccountDataSize|null[0]
+        enum entry HarvestWithheldTokensToMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.HarvestWithheldTokensToMint|null[0]
+        enum entry HarvestWithheldTokensToMintForConfidentialTransferFee // net.avianlabs.solana.domain.program/Token2022Program.Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee|null[0]
+        enum entry InitializeAccount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeAccount|null[0]
+        enum entry InitializeAccount2 // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeAccount2|null[0]
+        enum entry InitializeAccount3 // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeAccount3|null[0]
+        enum entry InitializeConfidentialTransferFee // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeConfidentialTransferFee|null[0]
+        enum entry InitializeConfidentialTransferMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeConfidentialTransferMint|null[0]
+        enum entry InitializeDefaultAccountState // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeDefaultAccountState|null[0]
+        enum entry InitializeGroupMemberPointer // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeGroupMemberPointer|null[0]
+        enum entry InitializeGroupPointer // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeGroupPointer|null[0]
+        enum entry InitializeImmutableOwner // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeImmutableOwner|null[0]
+        enum entry InitializeInterestBearingMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeInterestBearingMint|null[0]
+        enum entry InitializeMetadataPointer // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeMetadataPointer|null[0]
+        enum entry InitializeMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeMint|null[0]
+        enum entry InitializeMint2 // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeMint2|null[0]
+        enum entry InitializeMintCloseAuthority // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeMintCloseAuthority|null[0]
+        enum entry InitializeMultisig // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeMultisig|null[0]
+        enum entry InitializeMultisig2 // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeMultisig2|null[0]
+        enum entry InitializeNonTransferableMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeNonTransferableMint|null[0]
+        enum entry InitializePausableConfig // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializePausableConfig|null[0]
+        enum entry InitializePermanentDelegate // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializePermanentDelegate|null[0]
+        enum entry InitializeScaledUiAmountMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeScaledUiAmountMint|null[0]
+        enum entry InitializeTransferFeeConfig // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeTransferFeeConfig|null[0]
+        enum entry InitializeTransferHook // net.avianlabs.solana.domain.program/Token2022Program.Instruction.InitializeTransferHook|null[0]
+        enum entry MintTo // net.avianlabs.solana.domain.program/Token2022Program.Instruction.MintTo|null[0]
+        enum entry MintToChecked // net.avianlabs.solana.domain.program/Token2022Program.Instruction.MintToChecked|null[0]
+        enum entry Pause // net.avianlabs.solana.domain.program/Token2022Program.Instruction.Pause|null[0]
+        enum entry Reallocate // net.avianlabs.solana.domain.program/Token2022Program.Instruction.Reallocate|null[0]
+        enum entry Resume // net.avianlabs.solana.domain.program/Token2022Program.Instruction.Resume|null[0]
+        enum entry Revoke // net.avianlabs.solana.domain.program/Token2022Program.Instruction.Revoke|null[0]
+        enum entry SetAuthority // net.avianlabs.solana.domain.program/Token2022Program.Instruction.SetAuthority|null[0]
+        enum entry SetTransferFee // net.avianlabs.solana.domain.program/Token2022Program.Instruction.SetTransferFee|null[0]
+        enum entry SyncNative // net.avianlabs.solana.domain.program/Token2022Program.Instruction.SyncNative|null[0]
+        enum entry ThawAccount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.ThawAccount|null[0]
+        enum entry Transfer // net.avianlabs.solana.domain.program/Token2022Program.Instruction.Transfer|null[0]
+        enum entry TransferChecked // net.avianlabs.solana.domain.program/Token2022Program.Instruction.TransferChecked|null[0]
+        enum entry TransferCheckedWithFee // net.avianlabs.solana.domain.program/Token2022Program.Instruction.TransferCheckedWithFee|null[0]
+        enum entry UiAmountToAmount // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UiAmountToAmount|null[0]
+        enum entry UnwrapLamports // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UnwrapLamports|null[0]
+        enum entry UpdateConfidentialTransferMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UpdateConfidentialTransferMint|null[0]
+        enum entry UpdateDefaultAccountState // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UpdateDefaultAccountState|null[0]
+        enum entry UpdateGroupMemberPointer // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UpdateGroupMemberPointer|null[0]
+        enum entry UpdateGroupPointer // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UpdateGroupPointer|null[0]
+        enum entry UpdateMetadataPointer // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UpdateMetadataPointer|null[0]
+        enum entry UpdateMultiplierScaledUiMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UpdateMultiplierScaledUiMint|null[0]
+        enum entry UpdateRateInterestBearingMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UpdateRateInterestBearingMint|null[0]
+        enum entry UpdateTransferHook // net.avianlabs.solana.domain.program/Token2022Program.Instruction.UpdateTransferHook|null[0]
+        enum entry WithdrawExcessLamports // net.avianlabs.solana.domain.program/Token2022Program.Instruction.WithdrawExcessLamports|null[0]
+        enum entry WithdrawWithheldTokensFromAccounts // net.avianlabs.solana.domain.program/Token2022Program.Instruction.WithdrawWithheldTokensFromAccounts|null[0]
+        enum entry WithdrawWithheldTokensFromAccountsForConfidentialTransferFee // net.avianlabs.solana.domain.program/Token2022Program.Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee|null[0]
+        enum entry WithdrawWithheldTokensFromMint // net.avianlabs.solana.domain.program/Token2022Program.Instruction.WithdrawWithheldTokensFromMint|null[0]
+        enum entry WithdrawWithheldTokensFromMintForConfidentialTransferFee // net.avianlabs.solana.domain.program/Token2022Program.Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee|null[0]
+
+        final val entries // net.avianlabs.solana.domain.program/Token2022Program.Instruction.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<net.avianlabs.solana.domain.program/Token2022Program.Instruction> // net.avianlabs.solana.domain.program/Token2022Program.Instruction.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val index // net.avianlabs.solana.domain.program/Token2022Program.Instruction.index|{}index[0]
+            final fun <get-index>(): kotlin/UByte // net.avianlabs.solana.domain.program/Token2022Program.Instruction.index.<get-index>|<get-index>(){}[0]
+
+        final fun valueOf(kotlin/String): net.avianlabs.solana.domain.program/Token2022Program.Instruction // net.avianlabs.solana.domain.program/Token2022Program.Instruction.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<net.avianlabs.solana.domain.program/Token2022Program.Instruction> // net.avianlabs.solana.domain.program/Token2022Program.Instruction.values|values#static(){}[0]
+    }
+
+    final class TransferFee { // net.avianlabs.solana.domain.program/Token2022Program.TransferFee|null[0]
+        constructor <init>(kotlin/ULong, kotlin/ULong, kotlin/UShort) // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.<init>|<init>(kotlin.ULong;kotlin.ULong;kotlin.UShort){}[0]
+
+        final val epoch // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.epoch|{}epoch[0]
+            final fun <get-epoch>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.epoch.<get-epoch>|<get-epoch>(){}[0]
+        final val maximumFee // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.maximumFee|{}maximumFee[0]
+            final fun <get-maximumFee>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.maximumFee.<get-maximumFee>|<get-maximumFee>(){}[0]
+        final val transferFeeBasisPoints // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.transferFeeBasisPoints|{}transferFeeBasisPoints[0]
+            final fun <get-transferFeeBasisPoints>(): kotlin/UShort // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.transferFeeBasisPoints.<get-transferFeeBasisPoints>|<get-transferFeeBasisPoints>(){}[0]
+
+        final fun component1(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.component1|component1(){}[0]
+        final fun component2(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.component2|component2(){}[0]
+        final fun component3(): kotlin/UShort // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.component3|component3(){}[0]
+        final fun copy(kotlin/ULong = ..., kotlin/ULong = ..., kotlin/UShort = ...): net.avianlabs.solana.domain.program/Token2022Program.TransferFee // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.copy|copy(kotlin.ULong;kotlin.ULong;kotlin.UShort){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.hashCode|hashCode(){}[0]
+        final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.serialize|serialize(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.TransferFee.toString|toString(){}[0]
+    }
+
+    final value class DecryptableBalance { // net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance|null[0]
+        constructor <init>(kotlin/ByteArray) // net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance.<init>|<init>(kotlin.ByteArray){}[0]
+
+        final val bytes // net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance.bytes|{}bytes[0]
+            final fun <get-bytes>(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance.bytes.<get-bytes>|<get-bytes>(){}[0]
+
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance.toString|toString(){}[0]
+    }
+
+    final value class EncryptedBalance { // net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance|null[0]
+        constructor <init>(kotlin/ByteArray) // net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance.<init>|<init>(kotlin.ByteArray){}[0]
+
+        final val bytes // net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance.bytes|{}bytes[0]
+            final fun <get-bytes>(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance.bytes.<get-bytes>|<get-bytes>(){}[0]
+
+        final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance.toString|toString(){}[0]
+    }
+
+    sealed class Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension|null[0]
+        abstract fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.serialize|serialize(){}[0]
+
+        final class ConfidentialTransferAccount : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount|null[0]
+            constructor <init>(kotlin/Boolean, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance, net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance, net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance, net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance, kotlin/Boolean, kotlin/Boolean, kotlin/ULong, kotlin/ULong, kotlin/ULong, kotlin/ULong) // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.<init>|<init>(kotlin.Boolean;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance;net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance;net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance;kotlin.Boolean;kotlin.Boolean;kotlin.ULong;kotlin.ULong;kotlin.ULong;kotlin.ULong){}[0]
+
+            final val actualPendingBalanceCreditCounter // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.actualPendingBalanceCreditCounter|{}actualPendingBalanceCreditCounter[0]
+                final fun <get-actualPendingBalanceCreditCounter>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.actualPendingBalanceCreditCounter.<get-actualPendingBalanceCreditCounter>|<get-actualPendingBalanceCreditCounter>(){}[0]
+            final val allowConfidentialCredits // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.allowConfidentialCredits|{}allowConfidentialCredits[0]
+                final fun <get-allowConfidentialCredits>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.allowConfidentialCredits.<get-allowConfidentialCredits>|<get-allowConfidentialCredits>(){}[0]
+            final val allowNonConfidentialCredits // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.allowNonConfidentialCredits|{}allowNonConfidentialCredits[0]
+                final fun <get-allowNonConfidentialCredits>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.allowNonConfidentialCredits.<get-allowNonConfidentialCredits>|<get-allowNonConfidentialCredits>(){}[0]
+            final val approved // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.approved|{}approved[0]
+                final fun <get-approved>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.approved.<get-approved>|<get-approved>(){}[0]
+            final val availableBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.availableBalance|{}availableBalance[0]
+                final fun <get-availableBalance>(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.availableBalance.<get-availableBalance>|<get-availableBalance>(){}[0]
+            final val decryptableAvailableBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.decryptableAvailableBalance|{}decryptableAvailableBalance[0]
+                final fun <get-decryptableAvailableBalance>(): net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.decryptableAvailableBalance.<get-decryptableAvailableBalance>|<get-decryptableAvailableBalance>(){}[0]
+            final val elgamalPubkey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.elgamalPubkey|{}elgamalPubkey[0]
+                final fun <get-elgamalPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.elgamalPubkey.<get-elgamalPubkey>|<get-elgamalPubkey>(){}[0]
+            final val expectedPendingBalanceCreditCounter // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.expectedPendingBalanceCreditCounter|{}expectedPendingBalanceCreditCounter[0]
+                final fun <get-expectedPendingBalanceCreditCounter>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.expectedPendingBalanceCreditCounter.<get-expectedPendingBalanceCreditCounter>|<get-expectedPendingBalanceCreditCounter>(){}[0]
+            final val maximumPendingBalanceCreditCounter // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.maximumPendingBalanceCreditCounter|{}maximumPendingBalanceCreditCounter[0]
+                final fun <get-maximumPendingBalanceCreditCounter>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.maximumPendingBalanceCreditCounter.<get-maximumPendingBalanceCreditCounter>|<get-maximumPendingBalanceCreditCounter>(){}[0]
+            final val pendingBalanceCreditCounter // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.pendingBalanceCreditCounter|{}pendingBalanceCreditCounter[0]
+                final fun <get-pendingBalanceCreditCounter>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.pendingBalanceCreditCounter.<get-pendingBalanceCreditCounter>|<get-pendingBalanceCreditCounter>(){}[0]
+            final val pendingBalanceHigh // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.pendingBalanceHigh|{}pendingBalanceHigh[0]
+                final fun <get-pendingBalanceHigh>(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.pendingBalanceHigh.<get-pendingBalanceHigh>|<get-pendingBalanceHigh>(){}[0]
+            final val pendingBalanceLow // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.pendingBalanceLow|{}pendingBalanceLow[0]
+                final fun <get-pendingBalanceLow>(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.pendingBalanceLow.<get-pendingBalanceLow>|<get-pendingBalanceLow>(){}[0]
+
+            final fun component1(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component1|component1(){}[0]
+            final fun component10(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component10|component10(){}[0]
+            final fun component11(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component11|component11(){}[0]
+            final fun component12(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component12|component12(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component2|component2(){}[0]
+            final fun component3(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component3|component3(){}[0]
+            final fun component4(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component4|component4(){}[0]
+            final fun component5(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component5|component5(){}[0]
+            final fun component6(): net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component6|component6(){}[0]
+            final fun component7(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component7|component7(){}[0]
+            final fun component8(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component8|component8(){}[0]
+            final fun component9(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.component9|component9(){}[0]
+            final fun copy(kotlin/Boolean = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance = ..., net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance = ..., net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance = ..., net.avianlabs.solana.domain.program/Token2022Program.DecryptableBalance = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/ULong = ..., kotlin/ULong = ..., kotlin/ULong = ..., kotlin/ULong = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.copy|copy(kotlin.Boolean;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance;net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance;net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance;net.avianlabs.solana.domain.program.Token2022Program.DecryptableBalance;kotlin.Boolean;kotlin.Boolean;kotlin.ULong;kotlin.ULong;kotlin.ULong;kotlin.ULong){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferAccount.toString|toString(){}[0]
+        }
+
+        final class ConfidentialTransferFee : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Boolean, net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance) // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Boolean;net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance){}[0]
+
+            final val authority // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.authority|{}authority[0]
+                final fun <get-authority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.authority.<get-authority>|<get-authority>(){}[0]
+            final val elgamalPubkey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.elgamalPubkey|{}elgamalPubkey[0]
+                final fun <get-elgamalPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.elgamalPubkey.<get-elgamalPubkey>|<get-elgamalPubkey>(){}[0]
+            final val harvestToMintEnabled // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.harvestToMintEnabled|{}harvestToMintEnabled[0]
+                final fun <get-harvestToMintEnabled>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.harvestToMintEnabled.<get-harvestToMintEnabled>|<get-harvestToMintEnabled>(){}[0]
+            final val withheldAmount // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.withheldAmount|{}withheldAmount[0]
+                final fun <get-withheldAmount>(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.withheldAmount.<get-withheldAmount>|<get-withheldAmount>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.component2|component2(){}[0]
+            final fun component3(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.component3|component3(){}[0]
+            final fun component4(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.component4|component4(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/Boolean = ..., net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Boolean;net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFee.toString|toString(){}[0]
+        }
+
+        final class ConfidentialTransferFeeAmount : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount|null[0]
+            constructor <init>(net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance) // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.<init>|<init>(net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance){}[0]
+
+            final val withheldAmount // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.withheldAmount|{}withheldAmount[0]
+                final fun <get-withheldAmount>(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.withheldAmount.<get-withheldAmount>|<get-withheldAmount>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.component1|component1(){}[0]
+            final fun copy(net.avianlabs.solana.domain.program/Token2022Program.EncryptedBalance = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.copy|copy(net.avianlabs.solana.domain.program.Token2022Program.EncryptedBalance){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferFeeAmount.toString|toString(){}[0]
+        }
+
+        final class ConfidentialTransferMint : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, kotlin/Boolean, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?) // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.Boolean;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+
+            final val auditorElgamalPubkey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.auditorElgamalPubkey|{}auditorElgamalPubkey[0]
+                final fun <get-auditorElgamalPubkey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.auditorElgamalPubkey.<get-auditorElgamalPubkey>|<get-auditorElgamalPubkey>(){}[0]
+            final val authority // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.authority|{}authority[0]
+                final fun <get-authority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.authority.<get-authority>|<get-authority>(){}[0]
+            final val autoApproveNewAccounts // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.autoApproveNewAccounts|{}autoApproveNewAccounts[0]
+                final fun <get-autoApproveNewAccounts>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.autoApproveNewAccounts.<get-autoApproveNewAccounts>|<get-autoApproveNewAccounts>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.component1|component1(){}[0]
+            final fun component2(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.component2|component2(){}[0]
+            final fun component3(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.component3|component3(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., kotlin/Boolean = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.Boolean;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialTransferMint.toString|toString(){}[0]
+        }
+
+        final class CpiGuard : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard|null[0]
+            constructor <init>(kotlin/Boolean) // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.<init>|<init>(kotlin.Boolean){}[0]
+
+            final val lockCpi // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.lockCpi|{}lockCpi[0]
+                final fun <get-lockCpi>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.lockCpi.<get-lockCpi>|<get-lockCpi>(){}[0]
+
+            final fun component1(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.component1|component1(){}[0]
+            final fun copy(kotlin/Boolean = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.copy|copy(kotlin.Boolean){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.CpiGuard.toString|toString(){}[0]
+        }
+
+        final class DefaultAccountState : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState|null[0]
+            constructor <init>(net.avianlabs.solana.domain.program/Token2022Program.AccountState) // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.<init>|<init>(net.avianlabs.solana.domain.program.Token2022Program.AccountState){}[0]
+
+            final val state // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.state|{}state[0]
+                final fun <get-state>(): net.avianlabs.solana.domain.program/Token2022Program.AccountState // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.state.<get-state>|<get-state>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.domain.program/Token2022Program.AccountState // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.component1|component1(){}[0]
+            final fun copy(net.avianlabs.solana.domain.program/Token2022Program.AccountState = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.copy|copy(net.avianlabs.solana.domain.program.Token2022Program.AccountState){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.DefaultAccountState.toString|toString(){}[0]
+        }
+
+        final class GroupMemberPointer : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?) // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+
+            final val authority // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.authority|{}authority[0]
+                final fun <get-authority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.authority.<get-authority>|<get-authority>(){}[0]
+            final val memberAddress // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.memberAddress|{}memberAddress[0]
+                final fun <get-memberAddress>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.memberAddress.<get-memberAddress>|<get-memberAddress>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.component2|component2(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupMemberPointer.toString|toString(){}[0]
+        }
+
+        final class GroupPointer : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?) // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+
+            final val authority // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.authority|{}authority[0]
+                final fun <get-authority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.authority.<get-authority>|<get-authority>(){}[0]
+            final val groupAddress // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.groupAddress|{}groupAddress[0]
+                final fun <get-groupAddress>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.groupAddress.<get-groupAddress>|<get-groupAddress>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.component2|component2(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.GroupPointer.toString|toString(){}[0]
+        }
+
+        final class InterestBearingConfig : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/Short, kotlin/ULong, kotlin/Short) // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.Short;kotlin.ULong;kotlin.Short){}[0]
+
+            final val currentRate // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.currentRate|{}currentRate[0]
+                final fun <get-currentRate>(): kotlin/Short // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.currentRate.<get-currentRate>|<get-currentRate>(){}[0]
+            final val initializationTimestamp // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.initializationTimestamp|{}initializationTimestamp[0]
+                final fun <get-initializationTimestamp>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.initializationTimestamp.<get-initializationTimestamp>|<get-initializationTimestamp>(){}[0]
+            final val lastUpdateTimestamp // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.lastUpdateTimestamp|{}lastUpdateTimestamp[0]
+                final fun <get-lastUpdateTimestamp>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.lastUpdateTimestamp.<get-lastUpdateTimestamp>|<get-lastUpdateTimestamp>(){}[0]
+            final val preUpdateAverageRate // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.preUpdateAverageRate|{}preUpdateAverageRate[0]
+                final fun <get-preUpdateAverageRate>(): kotlin/Short // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.preUpdateAverageRate.<get-preUpdateAverageRate>|<get-preUpdateAverageRate>(){}[0]
+            final val rateAuthority // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.rateAuthority|{}rateAuthority[0]
+                final fun <get-rateAuthority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.rateAuthority.<get-rateAuthority>|<get-rateAuthority>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.component1|component1(){}[0]
+            final fun component2(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.component2|component2(){}[0]
+            final fun component3(): kotlin/Short // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.component3|component3(){}[0]
+            final fun component4(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.component4|component4(){}[0]
+            final fun component5(): kotlin/Short // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.component5|component5(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/ULong = ..., kotlin/Short = ..., kotlin/ULong = ..., kotlin/Short = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.Short;kotlin.ULong;kotlin.Short){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.InterestBearingConfig.toString|toString(){}[0]
+        }
+
+        final class MemoTransfer : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer|null[0]
+            constructor <init>(kotlin/Boolean) // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.<init>|<init>(kotlin.Boolean){}[0]
+
+            final val requireIncomingTransferMemos // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.requireIncomingTransferMemos|{}requireIncomingTransferMemos[0]
+                final fun <get-requireIncomingTransferMemos>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.requireIncomingTransferMemos.<get-requireIncomingTransferMemos>|<get-requireIncomingTransferMemos>(){}[0]
+
+            final fun component1(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.component1|component1(){}[0]
+            final fun copy(kotlin/Boolean = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.copy|copy(kotlin.Boolean){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.MemoTransfer.toString|toString(){}[0]
+        }
+
+        final class MetadataPointer : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey?) // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+
+            final val authority // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.authority|{}authority[0]
+                final fun <get-authority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.authority.<get-authority>|<get-authority>(){}[0]
+            final val metadataAddress // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.metadataAddress|{}metadataAddress[0]
+                final fun <get-metadataAddress>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.metadataAddress.<get-metadataAddress>|<get-metadataAddress>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.component2|component2(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey?){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.MetadataPointer.toString|toString(){}[0]
+        }
+
+        final class MintCloseAuthority : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+            final val closeAuthority // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.closeAuthority|{}closeAuthority[0]
+                final fun <get-closeAuthority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.closeAuthority.<get-closeAuthority>|<get-closeAuthority>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.component1|component1(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.MintCloseAuthority.toString|toString(){}[0]
+        }
+
+        final class PausableConfig : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, kotlin/Boolean) // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.Boolean){}[0]
+
+            final val authority // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.authority|{}authority[0]
+                final fun <get-authority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.authority.<get-authority>|<get-authority>(){}[0]
+            final val paused // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.paused|{}paused[0]
+                final fun <get-paused>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.paused.<get-paused>|<get-paused>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.component1|component1(){}[0]
+            final fun component2(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.component2|component2(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., kotlin/Boolean = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;kotlin.Boolean){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableConfig.toString|toString(){}[0]
+        }
+
+        final class PermanentDelegate : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+            final val delegate // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.delegate|{}delegate[0]
+                final fun <get-delegate>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.delegate.<get-delegate>|<get-delegate>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.component1|component1(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.PermanentDelegate.toString|toString(){}[0]
+        }
+
+        final class ScaledUiAmountConfig : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Double, kotlin/ULong, kotlin/Double) // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Double;kotlin.ULong;kotlin.Double){}[0]
+
+            final val authority // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.authority|{}authority[0]
+                final fun <get-authority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.authority.<get-authority>|<get-authority>(){}[0]
+            final val multiplier // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.multiplier|{}multiplier[0]
+                final fun <get-multiplier>(): kotlin/Double // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.multiplier.<get-multiplier>|<get-multiplier>(){}[0]
+            final val newMultiplier // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.newMultiplier|{}newMultiplier[0]
+                final fun <get-newMultiplier>(): kotlin/Double // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.newMultiplier.<get-newMultiplier>|<get-newMultiplier>(){}[0]
+            final val newMultiplierEffectiveTimestamp // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.newMultiplierEffectiveTimestamp|{}newMultiplierEffectiveTimestamp[0]
+                final fun <get-newMultiplierEffectiveTimestamp>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.newMultiplierEffectiveTimestamp.<get-newMultiplierEffectiveTimestamp>|<get-newMultiplierEffectiveTimestamp>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.component1|component1(){}[0]
+            final fun component2(): kotlin/Double // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.component2|component2(){}[0]
+            final fun component3(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.component3|component3(){}[0]
+            final fun component4(): kotlin/Double // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.component4|component4(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/Double = ..., kotlin/ULong = ..., kotlin/Double = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Double;kotlin.ULong;kotlin.Double){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.ScaledUiAmountConfig.toString|toString(){}[0]
+        }
+
+        final class TokenGroup : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, kotlin/ULong) // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.ULong){}[0]
+
+            final val maxSize // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.maxSize|{}maxSize[0]
+                final fun <get-maxSize>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.maxSize.<get-maxSize>|<get-maxSize>(){}[0]
+            final val mint // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.mint|{}mint[0]
+                final fun <get-mint>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.mint.<get-mint>|<get-mint>(){}[0]
+            final val size // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.size|{}size[0]
+                final fun <get-size>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.size.<get-size>|<get-size>(){}[0]
+            final val updateAuthority // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.updateAuthority|{}updateAuthority[0]
+                final fun <get-updateAuthority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.updateAuthority.<get-updateAuthority>|<get-updateAuthority>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.component2|component2(){}[0]
+            final fun component3(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.component3|component3(){}[0]
+            final fun component4(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.component4|component4(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/ULong = ..., kotlin/ULong = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;kotlin.ULong){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroup.toString|toString(){}[0]
+        }
+
+        final class TokenGroupMember : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong) // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+
+            final val group // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.group|{}group[0]
+                final fun <get-group>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.group.<get-group>|<get-group>(){}[0]
+            final val memberNumber // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.memberNumber|{}memberNumber[0]
+                final fun <get-memberNumber>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.memberNumber.<get-memberNumber>|<get-memberNumber>(){}[0]
+            final val mint // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.mint|{}mint[0]
+                final fun <get-mint>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.mint.<get-mint>|<get-mint>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.component2|component2(){}[0]
+            final fun component3(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.component3|component3(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/ULong = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenGroupMember.toString|toString(){}[0]
+        }
+
+        final class TokenMetadata : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey?, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/String, kotlin/String, kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/String>) // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+
+            final val additionalMetadata // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.additionalMetadata|{}additionalMetadata[0]
+                final fun <get-additionalMetadata>(): kotlin.collections/Map<kotlin/String, kotlin/String> // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.additionalMetadata.<get-additionalMetadata>|<get-additionalMetadata>(){}[0]
+            final val mint // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.mint|{}mint[0]
+                final fun <get-mint>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.mint.<get-mint>|<get-mint>(){}[0]
+            final val name // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.name|{}name[0]
+                final fun <get-name>(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.name.<get-name>|<get-name>(){}[0]
+            final val symbol // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.symbol|{}symbol[0]
+                final fun <get-symbol>(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.symbol.<get-symbol>|<get-symbol>(){}[0]
+            final val updateAuthority // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.updateAuthority|{}updateAuthority[0]
+                final fun <get-updateAuthority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.updateAuthority.<get-updateAuthority>|<get-updateAuthority>(){}[0]
+            final val uri // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.uri|{}uri[0]
+                final fun <get-uri>(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.uri.<get-uri>|<get-uri>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey? // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.component2|component2(){}[0]
+            final fun component3(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.component3|component3(){}[0]
+            final fun component4(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.component4|component4(){}[0]
+            final fun component5(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.component5|component5(){}[0]
+            final fun component6(): kotlin.collections/Map<kotlin/String, kotlin/String> // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.component6|component6(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey? = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey?;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.String;kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TokenMetadata.toString|toString(){}[0]
+        }
+
+        final class TransferFeeAmount : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount|null[0]
+            constructor <init>(kotlin/ULong) // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.<init>|<init>(kotlin.ULong){}[0]
+
+            final val withheldAmount // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.withheldAmount|{}withheldAmount[0]
+                final fun <get-withheldAmount>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.withheldAmount.<get-withheldAmount>|<get-withheldAmount>(){}[0]
+
+            final fun component1(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.component1|component1(){}[0]
+            final fun copy(kotlin/ULong = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.copy|copy(kotlin.ULong){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeAmount.toString|toString(){}[0]
+        }
+
+        final class TransferFeeConfig : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ULong, net.avianlabs.solana.domain.program/Token2022Program.TransferFee, net.avianlabs.solana.domain.program/Token2022Program.TransferFee) // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;net.avianlabs.solana.domain.program.Token2022Program.TransferFee;net.avianlabs.solana.domain.program.Token2022Program.TransferFee){}[0]
+
+            final val newerTransferFee // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.newerTransferFee|{}newerTransferFee[0]
+                final fun <get-newerTransferFee>(): net.avianlabs.solana.domain.program/Token2022Program.TransferFee // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.newerTransferFee.<get-newerTransferFee>|<get-newerTransferFee>(){}[0]
+            final val olderTransferFee // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.olderTransferFee|{}olderTransferFee[0]
+                final fun <get-olderTransferFee>(): net.avianlabs.solana.domain.program/Token2022Program.TransferFee // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.olderTransferFee.<get-olderTransferFee>|<get-olderTransferFee>(){}[0]
+            final val transferFeeConfigAuthority // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.transferFeeConfigAuthority|{}transferFeeConfigAuthority[0]
+                final fun <get-transferFeeConfigAuthority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.transferFeeConfigAuthority.<get-transferFeeConfigAuthority>|<get-transferFeeConfigAuthority>(){}[0]
+            final val withdrawWithheldAuthority // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.withdrawWithheldAuthority|{}withdrawWithheldAuthority[0]
+                final fun <get-withdrawWithheldAuthority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.withdrawWithheldAuthority.<get-withdrawWithheldAuthority>|<get-withdrawWithheldAuthority>(){}[0]
+            final val withheldAmount // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.withheldAmount|{}withheldAmount[0]
+                final fun <get-withheldAmount>(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.withheldAmount.<get-withheldAmount>|<get-withheldAmount>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.component2|component2(){}[0]
+            final fun component3(): kotlin/ULong // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.component3|component3(){}[0]
+            final fun component4(): net.avianlabs.solana.domain.program/Token2022Program.TransferFee // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.component4|component4(){}[0]
+            final fun component5(): net.avianlabs.solana.domain.program/Token2022Program.TransferFee // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.component5|component5(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/ULong = ..., net.avianlabs.solana.domain.program/Token2022Program.TransferFee = ..., net.avianlabs.solana.domain.program/Token2022Program.TransferFee = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ULong;net.avianlabs.solana.domain.program.Token2022Program.TransferFee;net.avianlabs.solana.domain.program.Token2022Program.TransferFee){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferFeeConfig.toString|toString(){}[0]
+        }
+
+        final class TransferHook : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook|null[0]
+            constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey) // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+
+            final val authority // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.authority|{}authority[0]
+                final fun <get-authority>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.authority.<get-authority>|<get-authority>(){}[0]
+            final val programId // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.programId|{}programId[0]
+                final fun <get-programId>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.programId.<get-programId>|<get-programId>(){}[0]
+
+            final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.component1|component1(){}[0]
+            final fun component2(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.component2|component2(){}[0]
+            final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHook.toString|toString(){}[0]
+        }
+
+        final class TransferHookAccount : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount|null[0]
+            constructor <init>(kotlin/Boolean) // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.<init>|<init>(kotlin.Boolean){}[0]
+
+            final val transferring // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.transferring|{}transferring[0]
+                final fun <get-transferring>(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.transferring.<get-transferring>|<get-transferring>(){}[0]
+
+            final fun component1(): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.component1|component1(){}[0]
+            final fun copy(kotlin/Boolean = ...): net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.copy|copy(kotlin.Boolean){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.Extension.TransferHookAccount.toString|toString(){}[0]
+        }
+
+        final object ConfidentialMintBurn : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialMintBurn|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.ConfidentialMintBurn.serialize|serialize(){}[0]
+        }
+
+        final object ImmutableOwner : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.ImmutableOwner|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.ImmutableOwner.serialize|serialize(){}[0]
+        }
+
+        final object NonTransferable : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.NonTransferable|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.NonTransferable.serialize|serialize(){}[0]
+        }
+
+        final object NonTransferableAccount : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.NonTransferableAccount|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.NonTransferableAccount.serialize|serialize(){}[0]
+        }
+
+        final object PausableAccount : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableAccount|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.PausableAccount.serialize|serialize(){}[0]
+        }
+
+        final object Uninitialized : net.avianlabs.solana.domain.program/Token2022Program.Extension { // net.avianlabs.solana.domain.program/Token2022Program.Extension.Uninitialized|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.Extension.Uninitialized.serialize|serialize(){}[0]
+        }
+    }
+
+    sealed class TokenMetadataField { // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField|null[0]
+        abstract fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.serialize|serialize(){}[0]
+
+        final class Key : net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField { // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key|null[0]
+            constructor <init>(kotlin/String) // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.<init>|<init>(kotlin.String){}[0]
+
+            final val value0 // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.value0|{}value0[0]
+                final fun <get-value0>(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.value0.<get-value0>|<get-value0>(){}[0]
+
+            final fun component1(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.component1|component1(){}[0]
+            final fun copy(kotlin/String = ...): net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.copy|copy(kotlin.String){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.hashCode|hashCode(){}[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.serialize|serialize(){}[0]
+            final fun toString(): kotlin/String // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Key.toString|toString(){}[0]
+        }
+
+        final object Name : net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField { // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Name|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Name.serialize|serialize(){}[0]
+        }
+
+        final object Symbol : net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField { // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Symbol|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Symbol.serialize|serialize(){}[0]
+        }
+
+        final object Uri : net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField { // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Uri|null[0]
+            final fun serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.program/Token2022Program.TokenMetadataField.Uri.serialize|serialize(){}[0]
+        }
+    }
+}
+
+final fun (net.avianlabs.solana.domain.core/Message).net.avianlabs.solana.domain.core/serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.core/serialize|serialize@net.avianlabs.solana.domain.core.Message(){}[0]
+final fun (net.avianlabs.solana.domain.core/VersionedMessage).net.avianlabs.solana.domain.core/serialize(): kotlin/ByteArray // net.avianlabs.solana.domain.core/serialize|serialize@net.avianlabs.solana.domain.core.VersionedMessage(){}[0]
+final fun (net.avianlabs.solana.domain.core/VersionedMessage.Companion).net.avianlabs.solana.domain.core/deserialize(kotlin/ByteArray): net.avianlabs.solana.domain.core/VersionedMessage // net.avianlabs.solana.domain.core/deserialize|deserialize@net.avianlabs.solana.domain.core.VersionedMessage.Companion(kotlin.ByteArray){}[0]
+final fun (net.avianlabs.solana.methods/TransactionResponse).net.avianlabs.solana.domain.core/decode(): net.avianlabs.solana.domain.core/DecodedTransaction? // net.avianlabs.solana.domain.core/decode|decode@net.avianlabs.solana.methods.TransactionResponse(){}[0]
+final fun (net.avianlabs.solana.tweetnacl.ed25519/PublicKey).net.avianlabs.solana.domain.program/associatedTokenAddress(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.program/ProgramDerivedAddress // net.avianlabs.solana.domain.program/associatedTokenAddress|associatedTokenAddress@net.avianlabs.solana.tweetnacl.ed25519.PublicKey(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
+final fun (net.avianlabs.solana.tweetnacl.ed25519/PublicKey.Companion).net.avianlabs.solana.domain.core/read(okio/BufferedSource): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/read|read@net.avianlabs.solana.tweetnacl.ed25519.PublicKey.Companion(okio.BufferedSource){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getAccountInfo(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<net.avianlabs.solana.methods/AccountInfo?>> // net.avianlabs.solana.methods/getAccountInfo|getAccountInfo@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getBalance(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<kotlin/Long>> // net.avianlabs.solana.methods/getBalance|getBalance@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getFeeForMessage(kotlin/ByteArray, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<kotlin/Long?>> // net.avianlabs.solana.methods/getFeeForMessage|getFeeForMessage@net.avianlabs.solana.SolanaClient(kotlin.ByteArray;net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getLatestBlockhash(net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<net.avianlabs.solana.methods/LatestBlockHash>> // net.avianlabs.solana.methods/getLatestBlockhash|getLatestBlockhash@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getMinimumBalanceForRentExemption(kotlin/Long, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<kotlin/Long> // net.avianlabs.solana.methods/getMinimumBalanceForRentExemption|getMinimumBalanceForRentExemption@net.avianlabs.solana.SolanaClient(kotlin.Long;net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getNonce(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.methods/NonceAccount? // net.avianlabs.solana.methods/getNonce|getNonce@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getRecentBlockhash(net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<net.avianlabs.solana.methods/RecentBlockHash>> // net.avianlabs.solana.methods/getRecentBlockhash|getRecentBlockhash@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getSignaturesForAddress(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<kotlin.collections/List<net.avianlabs.solana.methods/SignatureInformation>> // net.avianlabs.solana.methods/getSignaturesForAddress|getSignaturesForAddress@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getTokenAccountBalance(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<net.avianlabs.solana.methods/TokenAmountInfo?>> // net.avianlabs.solana.methods/getTokenAccountBalance|getTokenAccountBalance@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getTransaction(kotlin/String, net.avianlabs.solana.domain.core/Commitment? = ..., kotlin/Int? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.methods/TransactionResponse?> // net.avianlabs.solana.methods/getTransaction|getTransaction@net.avianlabs.solana.SolanaClient(kotlin.String;net.avianlabs.solana.domain.core.Commitment?;kotlin.Int?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/isBlockHashValid(kotlin/String, net.avianlabs.solana.domain.core/Commitment? = ..., kotlin/Long? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<kotlin/Boolean>> // net.avianlabs.solana.methods/isBlockHashValid|isBlockHashValid@net.avianlabs.solana.SolanaClient(kotlin.String;net.avianlabs.solana.domain.core.Commitment?;kotlin.Long?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/requestAirdrop(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/Long, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<kotlin/String> // net.avianlabs.solana.methods/requestAirdrop|requestAirdrop@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.Long;net.avianlabs.solana.domain.core.Commitment?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/sendTransaction(net.avianlabs.solana.domain.core/SignedTransaction, kotlin/Boolean = ..., net.avianlabs.solana.domain.core/Commitment = ..., kotlin/Int? = ..., kotlin/Long? = ...): net.avianlabs.solana.client/Response<kotlin/String> // net.avianlabs.solana.methods/sendTransaction|sendTransaction@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.domain.core.SignedTransaction;kotlin.Boolean;net.avianlabs.solana.domain.core.Commitment;kotlin.Int?;kotlin.Long?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/sendTransaction(net.avianlabs.solana.domain.core/VersionedTransaction, kotlin/Boolean = ..., net.avianlabs.solana.domain.core/Commitment = ..., kotlin/Int? = ..., kotlin/Long? = ...): net.avianlabs.solana.client/Response<kotlin/String> // net.avianlabs.solana.methods/sendTransaction|sendTransaction@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.domain.core.VersionedTransaction;kotlin.Boolean;net.avianlabs.solana.domain.core.Commitment;kotlin.Int?;kotlin.Long?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/simulateTransaction(net.avianlabs.solana.domain.core/SignedTransaction, net.avianlabs.solana.domain.core/Commitment? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/ULong? = ..., kotlin/Boolean? = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin/Int? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<net.avianlabs.solana.methods/SimulateTransactionResponse>> // net.avianlabs.solana.methods/simulateTransaction|simulateTransaction@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.domain.core.SignedTransaction;net.avianlabs.solana.domain.core.Commitment?;kotlin.Boolean?;kotlin.Boolean?;kotlin.ULong?;kotlin.Boolean?;kotlin.collections.List<kotlin.String>?;kotlin.Int?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/simulateTransaction(net.avianlabs.solana.domain.core/Transaction, net.avianlabs.solana.domain.core/Commitment? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/ULong? = ..., kotlin/Boolean? = ..., kotlin.collections/List<kotlin/String>? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<net.avianlabs.solana.methods/SimulateTransactionResponse>> // net.avianlabs.solana.methods/simulateTransaction|simulateTransaction@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.domain.core.Transaction;net.avianlabs.solana.domain.core.Commitment?;kotlin.Boolean?;kotlin.Boolean?;kotlin.ULong?;kotlin.Boolean?;kotlin.collections.List<kotlin.String>?){}[0]
+final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/simulateTransaction(net.avianlabs.solana.domain.core/VersionedTransaction, net.avianlabs.solana.domain.core/Commitment? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/ULong? = ..., kotlin/Boolean? = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin/Int? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<net.avianlabs.solana.methods/SimulateTransactionResponse>> // net.avianlabs.solana.methods/simulateTransaction|simulateTransaction@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.domain.core.VersionedTransaction;net.avianlabs.solana.domain.core.Commitment?;kotlin.Boolean?;kotlin.Boolean?;kotlin.ULong?;kotlin.Boolean?;kotlin.collections.List<kotlin.String>?;kotlin.Int?){}[0]
+
+// Targets: [ios]
+final val net.avianlabs.solana.domain.core/signatureData // net.avianlabs.solana.domain.core/signatureData|@net.avianlabs.solana.domain.core.SignaturePublicKeyPair{}signatureData[0]
+    final fun (net.avianlabs.solana.domain.core/SignaturePublicKeyPair).<get-signatureData>(): platform.Foundation/NSData? // net.avianlabs.solana.domain.core/signatureData.<get-signatureData>|<get-signatureData>@net.avianlabs.solana.domain.core.SignaturePublicKeyPair(){}[0]
+
+// Targets: [ios]
+final fun (net.avianlabs.solana.domain.core/SignedTransaction).net.avianlabs.solana.domain.core/serializeData(): platform.Foundation/NSData // net.avianlabs.solana.domain.core/serializeData|serializeData@net.avianlabs.solana.domain.core.SignedTransaction(){}[0]
+
+// Targets: [ios]
+final fun (net.avianlabs.solana.domain.core/VersionedTransaction).net.avianlabs.solana.domain.core/serializeData(): platform.Foundation/NSData // net.avianlabs.solana.domain.core/serializeData|serializeData@net.avianlabs.solana.domain.core.VersionedTransaction(){}[0]

--- a/tweetnacl-multiplatform/api/tweetnacl-multiplatform.api
+++ b/tweetnacl-multiplatform/api/tweetnacl-multiplatform.api
@@ -1,0 +1,96 @@
+public final class net/avianlabs/solana/tweetnacl/SecureRandom_jvmKt {
+	public static final fun secureRandomBytes (I)[B
+}
+
+public abstract interface class net/avianlabs/solana/tweetnacl/TweetNaCl {
+}
+
+public abstract interface class net/avianlabs/solana/tweetnacl/TweetNaCl$SecretBox {
+	public static final field Companion Lnet/avianlabs/solana/tweetnacl/TweetNaCl$SecretBox$Companion;
+	public static final field KEY_BYTES I
+	public static final field NONCE_BYTES I
+	public abstract fun box ([B[B)[B
+	public abstract fun open ([B[B)[B
+}
+
+public final class net/avianlabs/solana/tweetnacl/TweetNaCl$SecretBox$Companion {
+	public static final field KEY_BYTES I
+	public static final field NONCE_BYTES I
+	public final fun invoke ([B)Lnet/avianlabs/solana/tweetnacl/TweetNaCl$SecretBox;
+}
+
+public abstract interface class net/avianlabs/solana/tweetnacl/TweetNaCl$Signature {
+	public static final field Companion Lnet/avianlabs/solana/tweetnacl/TweetNaCl$Signature$Companion;
+	public static final field PUBLIC_KEY_BYTES I
+	public static final field SECRET_KEY_BYTES I
+	public static final field SEED_BYTES I
+	public static final field SIGNATURE_BYTES I
+	public abstract fun generateKey ([B)Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;
+	public abstract fun isOnCurve ([B)Z
+	public abstract fun sign ([B[B)[B
+}
+
+public final class net/avianlabs/solana/tweetnacl/TweetNaCl$Signature$Companion : net/avianlabs/solana/tweetnacl/TweetNaCl$Signature {
+	public static final field PUBLIC_KEY_BYTES I
+	public static final field SECRET_KEY_BYTES I
+	public static final field SEED_BYTES I
+	public static final field SIGNATURE_BYTES I
+	public fun generateKey ([B)Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;
+	public fun isOnCurve ([B)Z
+	public fun sign ([B[B)[B
+}
+
+public final class net/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair {
+	public static final field Companion Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair$Companion;
+	public fun <init> (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[B)V
+	public final fun component1 ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun component2 ()[B
+	public final fun copy (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[B)Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[BILjava/lang/Object;)Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPublicKey ()Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public final fun getSecretKey ()[B
+	public fun hashCode ()I
+	public final fun sign ([B)[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair$Companion {
+	public final fun fromBase58 (Ljava/lang/String;)Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;
+	public final fun fromSecretKeyBytes ([B)Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;
+	public final fun generate ()Lnet/avianlabs/solana/tweetnacl/ed25519/Ed25519Keypair;
+}
+
+public final class net/avianlabs/solana/tweetnacl/ed25519/PublicKey {
+	public static final field Companion Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey$Companion;
+	public fun <init> ([B)V
+	public final fun component1 ()[B
+	public final fun copy ([B)Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public static synthetic fun copy$default (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;[BILjava/lang/Object;)Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()[B
+	public fun hashCode ()I
+	public final fun isOnCurve ()Z
+	public final fun toBase58 ()Ljava/lang/String;
+	public final fun toByteArray ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/avianlabs/solana/tweetnacl/ed25519/PublicKey$Companion {
+	public final fun fromBase58 (Ljava/lang/String;)Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
+}
+
+public final class net/avianlabs/solana/tweetnacl/vendor/Base58Kt {
+	public static final fun decodeBase58 (Ljava/lang/String;)[B
+	public static final fun decodeBase58WithChecksum (Ljava/lang/String;)[B
+	public static final fun encodeToBase58String ([B)Ljava/lang/String;
+	public static final fun encodeToBase58WithChecksum ([B)Ljava/lang/String;
+	public static final fun sha256 (Ljava/lang/String;)[B
+	public static final fun sha256 ([B)[B
+}
+
+public final class net/avianlabs/solana/tweetnacl/vendor/Sha256 {
+	public static final field INSTANCE Lnet/avianlabs/solana/tweetnacl/vendor/Sha256;
+	public final fun digest ([B)[B
+}
+

--- a/tweetnacl-multiplatform/api/tweetnacl-multiplatform.klib.api
+++ b/tweetnacl-multiplatform/api/tweetnacl-multiplatform.klib.api
@@ -1,0 +1,120 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, linuxX64, mingwX64]
+// Alias: ios => [iosArm64, iosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <net.avianlabs.solana:tweetnacl-multiplatform>
+abstract interface net.avianlabs.solana.tweetnacl/TweetNaCl { // net.avianlabs.solana.tweetnacl/TweetNaCl|null[0]
+    abstract interface SecretBox { // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox|null[0]
+        abstract fun box(kotlin/ByteArray, kotlin/ByteArray): kotlin/ByteArray? // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox.box|box(kotlin.ByteArray;kotlin.ByteArray){}[0]
+        abstract fun open(kotlin/ByteArray, kotlin/ByteArray): kotlin/ByteArray? // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox.open|open(kotlin.ByteArray;kotlin.ByteArray){}[0]
+
+        final object Companion { // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox.Companion|null[0]
+            final const val KEY_BYTES // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox.Companion.KEY_BYTES|{}KEY_BYTES[0]
+                final fun <get-KEY_BYTES>(): kotlin/Int // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox.Companion.KEY_BYTES.<get-KEY_BYTES>|<get-KEY_BYTES>(){}[0]
+            final const val NONCE_BYTES // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox.Companion.NONCE_BYTES|{}NONCE_BYTES[0]
+                final fun <get-NONCE_BYTES>(): kotlin/Int // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox.Companion.NONCE_BYTES.<get-NONCE_BYTES>|<get-NONCE_BYTES>(){}[0]
+
+            final fun invoke(kotlin/ByteArray): net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox // net.avianlabs.solana.tweetnacl/TweetNaCl.SecretBox.Companion.invoke|invoke(kotlin.ByteArray){}[0]
+        }
+    }
+
+    abstract interface Signature { // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature|null[0]
+        abstract fun generateKey(kotlin/ByteArray): net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.generateKey|generateKey(kotlin.ByteArray){}[0]
+        abstract fun isOnCurve(kotlin/ByteArray): kotlin/Boolean // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.isOnCurve|isOnCurve(kotlin.ByteArray){}[0]
+        abstract fun sign(kotlin/ByteArray, kotlin/ByteArray): kotlin/ByteArray // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.sign|sign(kotlin.ByteArray;kotlin.ByteArray){}[0]
+
+        final object Companion : net.avianlabs.solana.tweetnacl/TweetNaCl.Signature { // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion|null[0]
+            final const val PUBLIC_KEY_BYTES // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.PUBLIC_KEY_BYTES|{}PUBLIC_KEY_BYTES[0]
+                final fun <get-PUBLIC_KEY_BYTES>(): kotlin/Int // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.PUBLIC_KEY_BYTES.<get-PUBLIC_KEY_BYTES>|<get-PUBLIC_KEY_BYTES>(){}[0]
+            final const val SECRET_KEY_BYTES // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.SECRET_KEY_BYTES|{}SECRET_KEY_BYTES[0]
+                final fun <get-SECRET_KEY_BYTES>(): kotlin/Int // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.SECRET_KEY_BYTES.<get-SECRET_KEY_BYTES>|<get-SECRET_KEY_BYTES>(){}[0]
+            final const val SEED_BYTES // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.SEED_BYTES|{}SEED_BYTES[0]
+                final fun <get-SEED_BYTES>(): kotlin/Int // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.SEED_BYTES.<get-SEED_BYTES>|<get-SEED_BYTES>(){}[0]
+            final const val SIGNATURE_BYTES // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.SIGNATURE_BYTES|{}SIGNATURE_BYTES[0]
+                final fun <get-SIGNATURE_BYTES>(): kotlin/Int // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.SIGNATURE_BYTES.<get-SIGNATURE_BYTES>|<get-SIGNATURE_BYTES>(){}[0]
+
+            final fun generateKey(kotlin/ByteArray): net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.generateKey|generateKey(kotlin.ByteArray){}[0]
+            final fun isOnCurve(kotlin/ByteArray): kotlin/Boolean // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.isOnCurve|isOnCurve(kotlin.ByteArray){}[0]
+            final fun sign(kotlin/ByteArray, kotlin/ByteArray): kotlin/ByteArray // net.avianlabs.solana.tweetnacl/TweetNaCl.Signature.Companion.sign|sign(kotlin.ByteArray;kotlin.ByteArray){}[0]
+        }
+    }
+}
+
+final class net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair { // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair|null[0]
+    constructor <init>(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, kotlin/ByteArray) // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.<init>|<init>(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ByteArray){}[0]
+
+    final val publicKey // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.publicKey|{}publicKey[0]
+        final fun <get-publicKey>(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.publicKey.<get-publicKey>|<get-publicKey>(){}[0]
+    final val secretKey // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.secretKey|{}secretKey[0]
+        final fun <get-secretKey>(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.secretKey.<get-secretKey>|<get-secretKey>(){}[0]
+
+    final fun component1(): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.component1|component1(){}[0]
+    final fun component2(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.component2|component2(){}[0]
+    final fun copy(net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ..., kotlin/ByteArray = ...): net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.copy|copy(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;kotlin.ByteArray){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.hashCode|hashCode(){}[0]
+    final fun sign(kotlin/ByteArray): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.sign|sign(kotlin.ByteArray){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.toString|toString(){}[0]
+
+    final object Companion { // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.Companion|null[0]
+        final fun fromBase58(kotlin/String): net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.Companion.fromBase58|fromBase58(kotlin.String){}[0]
+        final fun fromSecretKeyBytes(kotlin/ByteArray): net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.Companion.fromSecretKeyBytes|fromSecretKeyBytes(kotlin.ByteArray){}[0]
+        final fun generate(): net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair // net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.Companion.generate|generate(){}[0]
+    }
+}
+
+final class net.avianlabs.solana.tweetnacl.ed25519/PublicKey { // net.avianlabs.solana.tweetnacl.ed25519/PublicKey|null[0]
+    constructor <init>(kotlin/ByteArray) // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.<init>|<init>(kotlin.ByteArray){}[0]
+
+    final val bytes // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.bytes|{}bytes[0]
+        final fun <get-bytes>(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.bytes.<get-bytes>|<get-bytes>(){}[0]
+
+    final fun component1(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.component1|component1(){}[0]
+    final fun copy(kotlin/ByteArray = ...): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.copy|copy(kotlin.ByteArray){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.hashCode|hashCode(){}[0]
+    final fun isOnCurve(): kotlin/Boolean // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.isOnCurve|isOnCurve(){}[0]
+    final fun toBase58(): kotlin/String // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.toBase58|toBase58(){}[0]
+    final fun toByteArray(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.toByteArray|toByteArray(){}[0]
+    final fun toString(): kotlin/String // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.toString|toString(){}[0]
+
+    final object Companion { // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.Companion|null[0]
+        final fun fromBase58(kotlin/String): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.tweetnacl.ed25519/PublicKey.Companion.fromBase58|fromBase58(kotlin.String){}[0]
+    }
+}
+
+final object net.avianlabs.solana.tweetnacl.vendor/Sha256 { // net.avianlabs.solana.tweetnacl.vendor/Sha256|null[0]
+    final fun digest(kotlin/ByteArray): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.vendor/Sha256.digest|digest(kotlin.ByteArray){}[0]
+}
+
+final fun (kotlin/ByteArray).net.avianlabs.solana.tweetnacl.vendor/encodeToBase58String(): kotlin/String // net.avianlabs.solana.tweetnacl.vendor/encodeToBase58String|encodeToBase58String@kotlin.ByteArray(){}[0]
+final fun (kotlin/ByteArray).net.avianlabs.solana.tweetnacl.vendor/encodeToBase58WithChecksum(): kotlin/String // net.avianlabs.solana.tweetnacl.vendor/encodeToBase58WithChecksum|encodeToBase58WithChecksum@kotlin.ByteArray(){}[0]
+final fun (kotlin/ByteArray).net.avianlabs.solana.tweetnacl.vendor/sha256(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.vendor/sha256|sha256@kotlin.ByteArray(){}[0]
+final fun (kotlin/String).net.avianlabs.solana.tweetnacl.vendor/decodeBase58(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.vendor/decodeBase58|decodeBase58@kotlin.String(){}[0]
+final fun (kotlin/String).net.avianlabs.solana.tweetnacl.vendor/decodeBase58WithChecksum(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.vendor/decodeBase58WithChecksum|decodeBase58WithChecksum@kotlin.String(){}[0]
+final fun (kotlin/String).net.avianlabs.solana.tweetnacl.vendor/sha256(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.vendor/sha256|sha256@kotlin.String(){}[0]
+final fun net.avianlabs.solana.tweetnacl/secureRandomBytes(kotlin/Int): kotlin/ByteArray // net.avianlabs.solana.tweetnacl/secureRandomBytes|secureRandomBytes(kotlin.Int){}[0]
+
+// Targets: [ios]
+final val net.avianlabs.solana.tweetnacl.ed25519/data // net.avianlabs.solana.tweetnacl.ed25519/data|@net.avianlabs.solana.tweetnacl.ed25519.PublicKey{}data[0]
+    final fun (net.avianlabs.solana.tweetnacl.ed25519/PublicKey).<get-data>(): platform.Foundation/NSData // net.avianlabs.solana.tweetnacl.ed25519/data.<get-data>|<get-data>@net.avianlabs.solana.tweetnacl.ed25519.PublicKey(){}[0]
+
+// Targets: [ios]
+final val net.avianlabs.solana.tweetnacl.ed25519/secretKeyData // net.avianlabs.solana.tweetnacl.ed25519/secretKeyData|@net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair{}secretKeyData[0]
+    final fun (net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair).<get-secretKeyData>(): platform.Foundation/NSData // net.avianlabs.solana.tweetnacl.ed25519/secretKeyData.<get-secretKeyData>|<get-secretKeyData>@net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair(){}[0]
+
+// Targets: [ios]
+final fun (kotlin/ByteArray).net.avianlabs.solana.tweetnacl.ed25519/toNSData(): platform.Foundation/NSData // net.avianlabs.solana.tweetnacl.ed25519/toNSData|toNSData@kotlin.ByteArray(){}[0]
+
+// Targets: [ios]
+final fun (net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair.Companion).net.avianlabs.solana.tweetnacl.ed25519/fromSecretKeyData(platform.Foundation/NSData): net.avianlabs.solana.tweetnacl.ed25519/Ed25519Keypair // net.avianlabs.solana.tweetnacl.ed25519/fromSecretKeyData|fromSecretKeyData@net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair.Companion(platform.Foundation.NSData){}[0]
+
+// Targets: [ios]
+final fun (platform.Foundation/NSData).net.avianlabs.solana.tweetnacl.ed25519/toKotlinByteArray(): kotlin/ByteArray // net.avianlabs.solana.tweetnacl.ed25519/toKotlinByteArray|toKotlinByteArray@platform.Foundation.NSData(){}[0]
+
+// Targets: [ios]
+final fun net.avianlabs.solana.tweetnacl.ed25519/PublicKey(platform.Foundation/NSData): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.tweetnacl.ed25519/PublicKey|PublicKey(platform.Foundation.NSData){}[0]


### PR DESCRIPTION
Wires up org.jetbrains.kotlinx.binary-compatibility-validator 0.18.1
at the root project. KLIB ABI validation is enabled (still flagged
@OptIn(ExperimentalBCVApi)) so all four KMP targets are checked, not
just JVM. The :codegen module is excluded since it's a build-only
project that doesn't get published.

apiDump generates the baseline; apiCheck (auto-wired into ./gradlew check)
will then guard against any unintentional public-API or ABI change in
the upcoming CryptoProvider refactor and okio swap.