### PR TITLE
Swap okio for kotlinx-io across solana-kotlin internals

### DIFF
--- a/codegen/src/main/kotlin/net/avianlabs/solana/codegen/generator/ProgramGenerator.kt
+++ b/codegen/src/main/kotlin/net/avianlabs/solana/codegen/generator/ProgramGenerator.kt
@@ -37,7 +37,15 @@ class ProgramGenerator(
         "net.avianlabs.solana.domain.program.Program.Companion",
         "createTransactionInstruction"
       )
-      .addImport("okio", "Buffer")
+      .addImport(
+        "kotlinx.io",
+        "Buffer",
+        "readByteArray",
+        "writeIntLe",
+        "writeLongLe",
+        "writeShortLe",
+        "writeString",
+      )
       .addType(generateProgramObject())
       .build()
   }
@@ -394,9 +402,9 @@ class ProgramGenerator(
 
   private fun addDiscriminatorWrite(builder: CodeBlock.Builder, format: String, discriminator: Int) {
     when (format) {
-      "u16" -> builder.addStatement("buffer.writeShortLe(%L)", discriminator)
+      "u16" -> builder.addStatement("buffer.writeShortLe(%L.toShort())", discriminator)
       "u32" -> builder.addStatement("buffer.writeIntLe(%L)", discriminator)
-      else -> builder.addStatement("buffer.writeByte(%L)", discriminator)
+      else -> builder.addStatement("buffer.writeByte(%L.toByte())", discriminator)
     }
   }
 
@@ -600,16 +608,16 @@ class ProgramGenerator(
       "numberTypeNode" -> when (typeNode.format) {
         "u64" -> addStatement("buffer.writeLongLe(%L.toLong())", paramName)
         "i64" -> addStatement("buffer.writeLongLe(%L)", paramName)
-        "u8" -> addStatement("buffer.writeByte(%L.toInt())", paramName)
-        "i8" -> addStatement("buffer.writeByte(%L.toInt())", paramName)
+        "u8" -> addStatement("buffer.writeByte(%L.toByte())", paramName)
+        "i8" -> addStatement("buffer.writeByte(%L)", paramName)
         "u32" -> addStatement("buffer.writeIntLe(%L.toInt())", paramName)
         "i32" -> addStatement("buffer.writeIntLe(%L)", paramName)
-        "u16", "shortU16" -> addStatement("buffer.writeShortLe(%L.toInt())", paramName)
-        "i16" -> addStatement("buffer.writeShortLe(%L.toInt())", paramName)
+        "u16", "shortU16" -> addStatement("buffer.writeShortLe(%L.toShort())", paramName)
+        "i16" -> addStatement("buffer.writeShortLe(%L)", paramName)
         "f32" -> addStatement("buffer.writeIntLe(%L.toRawBits())", paramName)
         "f64" -> addStatement("buffer.writeLongLe(%L.toRawBits())", paramName)
       }
-      "booleanTypeNode" -> addStatement("buffer.writeByte(if (%L) 1 else 0)", paramName)
+      "booleanTypeNode" -> addStatement("buffer.writeByte((if (%L) 1 else 0).toByte())", paramName)
       "bytesTypeNode" -> addStatement("buffer.write(%L)", paramName)
       "stringTypeNode" -> {
         addStatement("val %LBytes = %L.encodeToByteArray()", paramName, paramName)
@@ -646,10 +654,10 @@ class ProgramGenerator(
       "optionTypeNode" -> {
         val innerType = typeNode.item ?: return
         beginControlFlow("if (%L != null)", paramName)
-        addStatement("buffer.writeByte(1)")
+        addStatement("buffer.writeByte(1.toByte())")
         addStructFieldSerialization(paramName, innerType)
         nextControlFlow("else")
-        addStatement("buffer.writeByte(0)")
+        addStatement("buffer.writeByte(0.toByte())")
         endControlFlow()
       }
       "definedTypeLinkNode" -> {
@@ -665,15 +673,15 @@ class ProgramGenerator(
             } else {
               val sizeFormat = getPrefixFormat(definedType.type.size) ?: "u8"
               when (sizeFormat) {
-                "u16" -> addStatement("buffer.writeShortLe(%L.value.toInt())", paramName)
+                "u16" -> addStatement("buffer.writeShortLe(%L.value.toShort())", paramName)
                 "u32" -> addStatement("buffer.writeIntLe(%L.value.toInt())", paramName)
-                else -> addStatement("buffer.writeByte(%L.value.toInt())", paramName)
+                else -> addStatement("buffer.writeByte(%L.value.toByte())", paramName)
               }
             }
           }
           "fixedSizeTypeNode" -> addStatement("buffer.write(%L.bytes)", paramName)
           "structTypeNode" -> addStatement("buffer.write(%L.serialize())", paramName)
-          else -> addStatement("buffer.writeByte(%L.value.toInt())", paramName)
+          else -> addStatement("buffer.writeByte(%L.value.toByte())", paramName)
         }
       }
       "amountTypeNode" -> {
@@ -960,10 +968,11 @@ class ProgramGenerator(
     }
     .unindent()
     .add("),\n")
-    .add("data = Buffer()\n")
+    .add("data = Buffer().apply {\n")
     .indent()
     .writeInstructions(instruction, args)
     .unindent()
+    .add("}.readByteArray(),\n")
     .unindent()
     .add(")\n")
     .build()
@@ -982,17 +991,17 @@ class ProgramGenerator(
         val hexData = defaultValue?.get("data")?.jsonPrimitive?.content
         if (hexData != null) {
           val byteArrayLiteral = hexToByteArrayLiteral(hexData)
-          add(".write($byteArrayLiteral)\n")
+          add("write($byteArrayLiteral)\n")
         }
       }
       "numberTypeNode" -> {
         when (discriminatorArg.type.format) {
-          "u8" -> add(".writeByte(Instruction.%L.index.toInt())\n", instruction.name.toPascalCase())
-          "u32" -> add(".writeIntLe(Instruction.%L.index.toInt())\n", instruction.name.toPascalCase())
-          else -> add(".writeIntLe(Instruction.%L.index.toInt())\n", instruction.name.toPascalCase())
+          "u8" -> add("writeByte(Instruction.%L.index.toByte())\n", instruction.name.toPascalCase())
+          "u32" -> add("writeIntLe(Instruction.%L.index.toInt())\n", instruction.name.toPascalCase())
+          else -> add("writeIntLe(Instruction.%L.index.toInt())\n", instruction.name.toPascalCase())
         }
       }
-      else -> add(".writeIntLe(Instruction.%L.index.toInt())\n", instruction.name.toPascalCase())
+      else -> add("writeIntLe(Instruction.%L.index.toInt())\n", instruction.name.toPascalCase())
     }
 
     // Write default values for omitted sub-discriminator arguments
@@ -1004,15 +1013,15 @@ class ProgramGenerator(
             when (arg.type.format) {
               "u64" -> {
                 val number = defaultValue["number"]?.jsonPrimitive?.long ?: return@forEach
-                add(".writeLongLe(%LL)\n", number)
+                add("writeLongLe(%LL)\n", number)
               }
               else -> {
                 val number = defaultValue["number"]?.jsonPrimitive?.int ?: return@forEach
                 when (arg.type.format) {
-                  "u8" -> add(".writeByte(%L)\n", number)
-                  "u16" -> add(".writeShortLe(%L)\n", number)
-                  "u32" -> add(".writeIntLe(%L)\n", number)
-                  else -> add(".writeByte(%L)\n", number)
+                  "u8" -> add("writeByte(%L.toByte())\n", number)
+                  "u16" -> add("writeShortLe(%L.toShort())\n", number)
+                  "u32" -> add("writeIntLe(%L)\n", number)
+                  else -> add("writeByte(%L.toByte())\n", number)
                 }
               }
             }
@@ -1020,7 +1029,7 @@ class ProgramGenerator(
           "bytesValueNode" -> {
             val hexData = defaultValue["data"]?.jsonPrimitive?.content ?: return@forEach
             val byteArrayLiteral = hexToByteArrayLiteral(hexData)
-            add(".write($byteArrayLiteral)\n")
+            add("write($byteArrayLiteral)\n")
           }
         }
       }
@@ -1030,7 +1039,6 @@ class ProgramGenerator(
       val paramName = if (arg.name.toCamelCase() == "programId") "targetProgramId" else arg.name.toCamelCase()
       addSerializationCode(paramName, arg.type)
     }
-    add(".readByteArray(),\n")
   }
 
   private fun hexToByteArrayLiteral(hex: String): String {
@@ -1041,64 +1049,58 @@ class ProgramGenerator(
   private fun CodeBlock.Builder.addSerializationCode(paramName: String, typeNode: TypeNode) {
     when (typeNode.kind) {
       "numberTypeNode" -> when (typeNode.format) {
-        "u64" -> add(".writeLongLe(%L.toLong())\n", paramName)
-        "i64" -> add(".writeLongLe(%L)\n", paramName)
-        "u8" -> add(".writeByte(%L.toInt())\n", paramName)
-        "i8" -> add(".writeByte(%L.toInt())\n", paramName)
-        "u32" -> add(".writeIntLe(%L.toInt())\n", paramName)
-        "i32" -> add(".writeIntLe(%L)\n", paramName)
-        "u16", "shortU16" -> add(".writeShortLe(%L.toInt())\n", paramName)
-        "i16" -> add(".writeShortLe(%L.toInt())\n", paramName)
-        "f32" -> add(".writeIntLe(%L.toRawBits())\n", paramName)
-        "f64" -> add(".writeLongLe(%L.toRawBits())\n", paramName)
+        "u64" -> add("writeLongLe(%L.toLong())\n", paramName)
+        "i64" -> add("writeLongLe(%L)\n", paramName)
+        "u8" -> add("writeByte(%L.toByte())\n", paramName)
+        "i8" -> add("writeByte(%L)\n", paramName)
+        "u32" -> add("writeIntLe(%L.toInt())\n", paramName)
+        "i32" -> add("writeIntLe(%L)\n", paramName)
+        "u16", "shortU16" -> add("writeShortLe(%L.toShort())\n", paramName)
+        "i16" -> add("writeShortLe(%L)\n", paramName)
+        "f32" -> add("writeIntLe(%L.toRawBits())\n", paramName)
+        "f64" -> add("writeLongLe(%L.toRawBits())\n", paramName)
       }
 
-      "publicKeyTypeNode" -> add(".write(%L.bytes)\n", paramName)
-      "stringTypeNode" -> add(".writeUtf8(%L)\n", paramName)
-      "booleanTypeNode" -> add(".writeByte(if (%L) 1 else 0)\n", paramName)
-      "bytesTypeNode" -> add(".write(%L)\n", paramName)
+      "publicKeyTypeNode" -> add("write(%L.bytes)\n", paramName)
+      "stringTypeNode" -> add("writeString(%L)\n", paramName)
+      "booleanTypeNode" -> add("writeByte((if (%L) 1 else 0).toByte())\n", paramName)
+      "bytesTypeNode" -> add("write(%L)\n", paramName)
 
       "optionTypeNode" -> {
         val innerType = typeNode.item ?: error("optionTypeNode missing item")
         val prefixFormat = getPrefixFormat(typeNode.prefix) ?: "u8"
-        add(".apply {\n")
-        add("  if (%L != null) {\n", paramName)
+        add("if (%L != null) {\n", paramName)
         when (prefixFormat) {
-          "u8" -> add("    writeByte(1)\n")
-          "u16" -> add("    writeShortLe(1)\n")
-          "u32" -> add("    writeIntLe(1)\n")
-          else -> add("    writeByte(1)\n")
+          "u8" -> add("  writeByte(1.toByte())\n")
+          "u16" -> add("  writeShortLe(1.toShort())\n")
+          "u32" -> add("  writeIntLe(1)\n")
+          else -> add("  writeByte(1.toByte())\n")
         }
-        add("    ").addSerializationCode(paramName, innerType)
-        add("  } else {\n")
+        add("  ").addSerializationCode(paramName, innerType)
+        add("} else {\n")
         when (prefixFormat) {
-          "u8" -> add("    writeByte(0)\n")
-          "u16" -> add("    writeShortLe(0)\n")
-          "u32" -> add("    writeIntLe(0)\n")
-          else -> add("    writeByte(0)\n")
+          "u8" -> add("  writeByte(0.toByte())\n")
+          "u16" -> add("  writeShortLe(0.toShort())\n")
+          "u32" -> add("  writeIntLe(0)\n")
+          else -> add("  writeByte(0.toByte())\n")
         }
-        add("  }\n")
         add("}\n")
       }
 
       "zeroableOptionTypeNode" -> {
         val innerType = typeNode.item ?: error("zeroableOptionTypeNode missing item")
         val zeroSize = getTypeSize(innerType)
-        add(".apply {\n")
-        add("  if (%L != null) {\n", paramName)
-        addSerializationCodeWithoutPrefix(paramName, innerType, "    ")
-        add("  } else {\n")
-        add("    write(ByteArray(%L))\n", zeroSize)
-        add("  }\n")
+        add("if (%L != null) {\n", paramName)
+        addSerializationCodeWithoutPrefix(paramName, innerType, "  ")
+        add("} else {\n")
+        add("  write(ByteArray(%L))\n", zeroSize)
         add("}\n")
       }
 
       "remainderOptionTypeNode" -> {
         val innerType = typeNode.item ?: error("remainderOptionTypeNode missing item")
-        add(".apply {\n")
-        add("  if (%L != null) {\n", paramName)
-        add("    ").addSerializationCode(paramName, innerType)
-        add("  }\n")
+        add("if (%L != null) {\n", paramName)
+        add("  ").addSerializationCode(paramName, innerType)
         add("}\n")
       }
 
@@ -1106,17 +1108,16 @@ class ProgramGenerator(
         val innerType = typeNode.type ?: error("sizePrefixTypeNode missing type")
         val prefixFormat = getPrefixFormat(typeNode.prefix) ?: "u64"
         if (innerType.kind == "stringTypeNode") {
-          add(".apply {\n")
-          add("  val bytes = %L.encodeToByteArray()\n", paramName)
+          val bytesVar = "${paramName}Bytes"
+          add("val %L = %L.encodeToByteArray()\n", bytesVar, paramName)
           when (prefixFormat) {
-            "u8" -> add("  writeByte(bytes.size)\n")
-            "u16" -> add("  writeShortLe(bytes.size)\n")
-            "u32" -> add("  writeIntLe(bytes.size)\n")
-            "u64" -> add("  writeLongLe(bytes.size.toLong())\n")
-            else -> add("  writeLongLe(bytes.size.toLong())\n")
+            "u8" -> add("writeByte(%L.size.toByte())\n", bytesVar)
+            "u16" -> add("writeShortLe(%L.size.toShort())\n", bytesVar)
+            "u32" -> add("writeIntLe(%L.size)\n", bytesVar)
+            "u64" -> add("writeLongLe(%L.size.toLong())\n", bytesVar)
+            else -> add("writeLongLe(%L.size.toLong())\n", bytesVar)
           }
-          add("  write(bytes)\n")
-          add("}\n")
+          add("write(%L)\n", bytesVar)
         } else {
           addSerializationCode(paramName, innerType)
         }
@@ -1151,21 +1152,17 @@ class ProgramGenerator(
       "mapTypeNode" -> {
         val keyType = typeNode.key ?: error("mapTypeNode missing key")
         val valueType = typeNode.value ?: error("mapTypeNode missing value")
-        add(".apply {\n")
-        add("  writeIntLe(%L.size)\n", paramName)
-        add("  %L.forEach { (k, v) ->\n", paramName)
-        add("    ").addSerializationCode("k", keyType)
-        add("    ").addSerializationCode("v", valueType)
-        add("  }\n")
+        add("writeIntLe(%L.size)\n", paramName)
+        add("%L.forEach { (k, v) ->\n", paramName)
+        add("  ").addSerializationCode("k", keyType)
+        add("  ").addSerializationCode("v", valueType)
         add("}\n")
       }
 
       "arrayTypeNode" -> {
         val itemType = typeNode.item ?: error("arrayTypeNode missing item")
-        add(".apply {\n")
-        add("  %L.forEach { item ->\n", paramName)
-        addSerializationCodeWithoutPrefix("item", itemType, "    ")
-        add("  }\n")
+        add("%L.forEach { item ->\n", paramName)
+        addSerializationCodeWithoutPrefix("item", itemType, "  ")
         add("}\n")
       }
 
@@ -1178,20 +1175,20 @@ class ProgramGenerator(
               it.kind == "enumStructVariantTypeNode" || it.kind == "enumTupleVariantTypeNode"
             } ?: false
             if (hasComplexVariants) {
-              add(".write(%L.serialize())\n", paramName)
+              add("write(%L.serialize())\n", paramName)
             } else {
               val sizeFormat = getPrefixFormat(definedType.type.size) ?: "u8"
               when (sizeFormat) {
-                "u8" -> add(".writeByte(%L.value.toInt())\n", paramName)
-                "u16" -> add(".writeShortLe(%L.value.toInt())\n", paramName)
-                "u32" -> add(".writeIntLe(%L.value.toInt())\n", paramName)
-                else -> add(".writeByte(%L.value.toInt())\n", paramName)
+                "u8" -> add("writeByte(%L.value.toByte())\n", paramName)
+                "u16" -> add("writeShortLe(%L.value.toShort())\n", paramName)
+                "u32" -> add("writeIntLe(%L.value.toInt())\n", paramName)
+                else -> add("writeByte(%L.value.toByte())\n", paramName)
               }
             }
           }
-          "fixedSizeTypeNode" -> add(".write(%L.bytes)\n", paramName)
-          "structTypeNode" -> add(".write(%L.serialize())\n", paramName)
-          else -> add(".writeByte(%L.value.toInt())\n", paramName)
+          "fixedSizeTypeNode" -> add("write(%L.bytes)\n", paramName)
+          "structTypeNode" -> add("write(%L.serialize())\n", paramName)
+          else -> add("writeByte(%L.value.toByte())\n", paramName)
         }
       }
 
@@ -1223,12 +1220,12 @@ class ProgramGenerator(
       "numberTypeNode" -> when (typeNode.format) {
         "u64" -> add("${indent}writeLongLe(%L.toLong())\n", paramName)
         "i64" -> add("${indent}writeLongLe(%L)\n", paramName)
-        "u8" -> add("${indent}writeByte(%L.toInt())\n", paramName)
-        "i8" -> add("${indent}writeByte(%L.toInt())\n", paramName)
+        "u8" -> add("${indent}writeByte(%L.toByte())\n", paramName)
+        "i8" -> add("${indent}writeByte(%L)\n", paramName)
         "u32" -> add("${indent}writeIntLe(%L.toInt())\n", paramName)
         "i32" -> add("${indent}writeIntLe(%L)\n", paramName)
-        "u16", "shortU16" -> add("${indent}writeShortLe(%L.toInt())\n", paramName)
-        "i16" -> add("${indent}writeShortLe(%L.toInt())\n", paramName)
+        "u16", "shortU16" -> add("${indent}writeShortLe(%L.toShort())\n", paramName)
+        "i16" -> add("${indent}writeShortLe(%L)\n", paramName)
         "f32" -> add("${indent}writeIntLe(%L.toRawBits())\n", paramName)
         "f64" -> add("${indent}writeLongLe(%L.toRawBits())\n", paramName)
       }
@@ -1246,14 +1243,14 @@ class ProgramGenerator(
             } else {
               val sizeFormat = getPrefixFormat(definedType.type.size) ?: "u8"
               when (sizeFormat) {
-                "u16" -> add("${indent}writeShortLe(%L.value.toInt())\n", paramName)
+                "u16" -> add("${indent}writeShortLe(%L.value.toShort())\n", paramName)
                 "u32" -> add("${indent}writeIntLe(%L.value.toInt())\n", paramName)
-                else -> add("${indent}writeByte(%L.value.toInt())\n", paramName)
+                else -> add("${indent}writeByte(%L.value.toByte())\n", paramName)
               }
             }
           }
           "fixedSizeTypeNode" -> add("${indent}write(%L.bytes)\n", paramName)
-          else -> add("${indent}writeByte(%L.value.toInt())\n", paramName)
+          else -> add("${indent}writeByte(%L.value.toByte())\n", paramName)
         }
       }
       else -> add("${indent}write(%L.serialize())\n", paramName)

--- a/codegen/src/test/kotlin/net/avianlabs/solana/codegen/generator/ProgramGeneratorTest.kt
+++ b/codegen/src/test/kotlin/net/avianlabs/solana/codegen/generator/ProgramGeneratorTest.kt
@@ -168,8 +168,8 @@ class ProgramGeneratorTest {
 
     val code = parseAndGenerate(idl)
     // u8 prefix means writeByte for the option discriminator
-    assertContains(code, "writeByte(1)")
-    assertContains(code, "writeByte(0)")
+    assertContains(code, "writeByte(1.toByte())")
+    assertContains(code, "writeByte(0.toByte())")
     // Should NOT contain writeIntLe for the option prefix
     assertFalse(code.contains("writeIntLe(1)"), "Should not use writeIntLe for u8 default option prefix")
   }
@@ -221,7 +221,7 @@ class ProgramGeneratorTest {
     """.trimIndent()
 
     val code = parseAndGenerate(idl)
-    assertContains(code, ".writeByte(enumValue.value.toInt())")
+    assertContains(code, "writeByte(enumValue.value.toByte())")
   }
 
   @Test
@@ -270,7 +270,7 @@ class ProgramGeneratorTest {
     """.trimIndent()
 
     val code = parseAndGenerate(idl)
-    assertContains(code, ".writeShortLe(enumValue.value.toInt())")
+    assertContains(code, "writeShortLe(enumValue.value.toShort())")
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,9 +20,9 @@ junit5 = "6.0.2"
 junitPioneer = "2.3.0"
 kermit = "2.0.6"
 kotlinxCoroutines = "1.10.2"
+kotlinxIo = "0.9.0"
 kotlinLogging = "7.0.14"
 ktor = "3.2.0"
-okio = "3.16.4"
 serialization = "1.10.0"
 
 [libraries]
@@ -35,7 +35,9 @@ kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlinLogging = { module = "io.github.oshai:kotlin-logging", version.ref = "kotlinLogging" }
 kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.18.1" }
+kotlinxIo = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinxIo" }
 ktorClientContentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+
 ktorClientCio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktorClientCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktorClientDarwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
@@ -44,7 +46,6 @@ ktorClientOkHttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor"
 ktorClientWinHttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "ktor" }
 ktorSerializationKotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktorUtils = { module = "io.ktor:ktor-utils", version.ref = "ktor" }
-okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 serializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 skie-configurationAnnotations = { module = "co.touchlab.skie:configuration-annotations", version.ref = "skie" }

--- a/solana-kotlin/api/jvm/solana-kotlin.api
+++ b/solana-kotlin/api/jvm/solana-kotlin.api
@@ -458,7 +458,6 @@ public final synthetic class net/avianlabs/solana/domain/core/FeeCalculator$$ser
 }
 
 public final class net/avianlabs/solana/domain/core/FeeCalculator$Companion {
-	public final fun read (Lokio/BufferedSource;)Lnet/avianlabs/solana/domain/core/FeeCalculator;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -521,11 +520,6 @@ public final class net/avianlabs/solana/domain/core/NonceAccountData {
 }
 
 public final class net/avianlabs/solana/domain/core/NonceAccountData$Companion {
-	public final fun read (Lokio/BufferedSource;)Lnet/avianlabs/solana/domain/core/NonceAccountData;
-}
-
-public final class net/avianlabs/solana/domain/core/PublicKeyKt {
-	public static final fun read (Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey$Companion;Lokio/BufferedSource;)Lnet/avianlabs/solana/tweetnacl/ed25519/PublicKey;
 }
 
 public final class net/avianlabs/solana/domain/core/SerializeMessageKt {

--- a/solana-kotlin/api/solana-kotlin.klib.api
+++ b/solana-kotlin/api/solana-kotlin.klib.api
@@ -314,7 +314,6 @@ final class net.avianlabs.solana.domain.core/FeeCalculator { // net.avianlabs.so
     }
 
     final object Companion { // net.avianlabs.solana.domain.core/FeeCalculator.Companion|null[0]
-        final fun read(okio/BufferedSource): net.avianlabs.solana.domain.core/FeeCalculator // net.avianlabs.solana.domain.core/FeeCalculator.Companion.read|read(okio.BufferedSource){}[0]
         final fun serializer(): kotlinx.serialization/KSerializer<net.avianlabs.solana.domain.core/FeeCalculator> // net.avianlabs.solana.domain.core/FeeCalculator.Companion.serializer|serializer(){}[0]
     }
 }
@@ -391,9 +390,7 @@ final class net.avianlabs.solana.domain.core/NonceAccountData { // net.avianlabs
     final fun hashCode(): kotlin/Int // net.avianlabs.solana.domain.core/NonceAccountData.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // net.avianlabs.solana.domain.core/NonceAccountData.toString|toString(){}[0]
 
-    final object Companion { // net.avianlabs.solana.domain.core/NonceAccountData.Companion|null[0]
-        final fun read(okio/BufferedSource): net.avianlabs.solana.domain.core/NonceAccountData // net.avianlabs.solana.domain.core/NonceAccountData.Companion.read|read(okio.BufferedSource){}[0]
-    }
+    final object Companion // net.avianlabs.solana.domain.core/NonceAccountData.Companion|null[0]
 }
 
 final class net.avianlabs.solana.domain.core/SignaturePubkeyPair { // net.avianlabs.solana.domain.core/SignaturePubkeyPair|null[0]
@@ -2608,7 +2605,6 @@ final fun (net.avianlabs.solana.domain.core/VersionedMessage).net.avianlabs.sola
 final fun (net.avianlabs.solana.domain.core/VersionedMessage.Companion).net.avianlabs.solana.domain.core/deserialize(kotlin/ByteArray): net.avianlabs.solana.domain.core/VersionedMessage // net.avianlabs.solana.domain.core/deserialize|deserialize@net.avianlabs.solana.domain.core.VersionedMessage.Companion(kotlin.ByteArray){}[0]
 final fun (net.avianlabs.solana.methods/TransactionResponse).net.avianlabs.solana.domain.core/decode(): net.avianlabs.solana.domain.core/DecodedTransaction? // net.avianlabs.solana.domain.core/decode|decode@net.avianlabs.solana.methods.TransactionResponse(){}[0]
 final fun (net.avianlabs.solana.tweetnacl.ed25519/PublicKey).net.avianlabs.solana.domain.program/associatedTokenAddress(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.tweetnacl.ed25519/PublicKey = ...): net.avianlabs.solana.domain.program/ProgramDerivedAddress // net.avianlabs.solana.domain.program/associatedTokenAddress|associatedTokenAddress@net.avianlabs.solana.tweetnacl.ed25519.PublicKey(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.tweetnacl.ed25519.PublicKey){}[0]
-final fun (net.avianlabs.solana.tweetnacl.ed25519/PublicKey.Companion).net.avianlabs.solana.domain.core/read(okio/BufferedSource): net.avianlabs.solana.tweetnacl.ed25519/PublicKey // net.avianlabs.solana.domain.core/read|read@net.avianlabs.solana.tweetnacl.ed25519.PublicKey.Companion(okio.BufferedSource){}[0]
 final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getAccountInfo(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<net.avianlabs.solana.methods/AccountInfo?>> // net.avianlabs.solana.methods/getAccountInfo|getAccountInfo@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.core.Commitment?){}[0]
 final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getBalance(net.avianlabs.solana.tweetnacl.ed25519/PublicKey, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<kotlin/Long>> // net.avianlabs.solana.methods/getBalance|getBalance@net.avianlabs.solana.SolanaClient(net.avianlabs.solana.tweetnacl.ed25519.PublicKey;net.avianlabs.solana.domain.core.Commitment?){}[0]
 final suspend fun (net.avianlabs.solana/SolanaClient).net.avianlabs.solana.methods/getFeeForMessage(kotlin/ByteArray, net.avianlabs.solana.domain.core/Commitment? = ...): net.avianlabs.solana.client/Response<net.avianlabs.solana.client/Response.RPC<kotlin/Long?>> // net.avianlabs.solana.methods/getFeeForMessage|getFeeForMessage@net.avianlabs.solana.SolanaClient(kotlin.ByteArray;net.avianlabs.solana.domain.core.Commitment?){}[0]

--- a/solana-kotlin/build.gradle.kts
+++ b/solana-kotlin/build.gradle.kts
@@ -69,7 +69,7 @@ kotlin {
         implementation(libs.ktorClientContentNegotiation)
         implementation(libs.ktorSerializationKotlinxJson)
         implementation(libs.kermit)
-        implementation(libs.okio)
+        implementation(libs.kotlinxIo)
         implementation(libs.skie.configurationAnnotations)
         implementation(libs.kotlinLogging)
       }

--- a/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/AssociatedTokenProgram.kt
+++ b/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/AssociatedTokenProgram.kt
@@ -9,11 +9,16 @@ package net.avianlabs.solana.domain.program
 
 import kotlin.Deprecated
 import kotlin.UByte
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.io.writeIntLe
+import kotlinx.io.writeLongLe
+import kotlinx.io.writeShortLe
+import kotlinx.io.writeString
 import net.avianlabs.solana.domain.core.AccountMeta
 import net.avianlabs.solana.domain.core.TransactionInstruction
 import net.avianlabs.solana.domain.program.Program.Companion.createTransactionInstruction
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
-import okio.Buffer
 
 public object AssociatedTokenProgram : Program {
   public override val programId: PublicKey =
@@ -40,9 +45,9 @@ public object AssociatedTokenProgram : Program {
       AccountMeta(systemProgram, isSigner = false, isWritable = false),
       AccountMeta(tokenProgram, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.CreateAssociatedToken.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.CreateAssociatedToken.index.toByte())
+    }.readByteArray(),
   )
 
   @Deprecated(
@@ -83,9 +88,9 @@ public object AssociatedTokenProgram : Program {
       AccountMeta(systemProgram, isSigner = false, isWritable = false),
       AccountMeta(tokenProgram, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.CreateAssociatedTokenIdempotent.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.CreateAssociatedTokenIdempotent.index.toByte())
+    }.readByteArray(),
   )
 
   @Deprecated(
@@ -136,9 +141,9 @@ public object AssociatedTokenProgram : Program {
       AccountMeta(walletAddress, isSigner = true, isWritable = true),
       AccountMeta(tokenProgram, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.RecoverNestedAssociatedToken.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.RecoverNestedAssociatedToken.index.toByte())
+    }.readByteArray(),
   )
 
   public enum class Instruction(

--- a/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/ComputeBudgetProgram.kt
+++ b/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/ComputeBudgetProgram.kt
@@ -10,10 +10,15 @@ package net.avianlabs.solana.domain.program
 import kotlin.UByte
 import kotlin.UInt
 import kotlin.ULong
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.io.writeIntLe
+import kotlinx.io.writeLongLe
+import kotlinx.io.writeShortLe
+import kotlinx.io.writeString
 import net.avianlabs.solana.domain.core.TransactionInstruction
 import net.avianlabs.solana.domain.program.Program.Companion.createTransactionInstruction
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
-import okio.Buffer
 
 public object ComputeBudgetProgram : Program {
   public override val programId: PublicKey =
@@ -24,21 +29,21 @@ public object ComputeBudgetProgram : Program {
     programId = programId,
     keys = listOf(
     ),
-    data = Buffer()
-      .writeByte(Instruction.RequestUnits.index.toInt())
-      .writeIntLe(units.toInt())
-      .writeIntLe(additionalFee.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.RequestUnits.index.toByte())
+      writeIntLe(units.toInt())
+      writeIntLe(additionalFee.toInt())
+    }.readByteArray(),
   )
 
   public fun requestHeapFrame(bytes: UInt): TransactionInstruction = createTransactionInstruction(
     programId = programId,
     keys = listOf(
     ),
-    data = Buffer()
-      .writeByte(Instruction.RequestHeapFrame.index.toInt())
-      .writeIntLe(bytes.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.RequestHeapFrame.index.toByte())
+      writeIntLe(bytes.toInt())
+    }.readByteArray(),
   )
 
   public fun setComputeUnitLimit(units: UInt): TransactionInstruction =
@@ -46,10 +51,10 @@ public object ComputeBudgetProgram : Program {
     programId = programId,
     keys = listOf(
     ),
-    data = Buffer()
-      .writeByte(Instruction.SetComputeUnitLimit.index.toInt())
-      .writeIntLe(units.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.SetComputeUnitLimit.index.toByte())
+      writeIntLe(units.toInt())
+    }.readByteArray(),
   )
 
   public fun setComputeUnitPrice(microLamports: ULong): TransactionInstruction =
@@ -57,10 +62,10 @@ public object ComputeBudgetProgram : Program {
     programId = programId,
     keys = listOf(
     ),
-    data = Buffer()
-      .writeByte(Instruction.SetComputeUnitPrice.index.toInt())
-      .writeLongLe(microLamports.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.SetComputeUnitPrice.index.toByte())
+      writeLongLe(microLamports.toLong())
+    }.readByteArray(),
   )
 
   public fun setLoadedAccountsDataSizeLimit(accountDataSizeLimit: UInt): TransactionInstruction =
@@ -68,10 +73,10 @@ public object ComputeBudgetProgram : Program {
     programId = programId,
     keys = listOf(
     ),
-    data = Buffer()
-      .writeByte(Instruction.SetLoadedAccountsDataSizeLimit.index.toInt())
-      .writeIntLe(accountDataSizeLimit.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.SetLoadedAccountsDataSizeLimit.index.toByte())
+      writeIntLe(accountDataSizeLimit.toInt())
+    }.readByteArray(),
   )
 
   public enum class Instruction(

--- a/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/SystemProgram.kt
+++ b/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/SystemProgram.kt
@@ -12,11 +12,16 @@ import kotlin.Long
 import kotlin.String
 import kotlin.UInt
 import kotlin.ULong
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.io.writeIntLe
+import kotlinx.io.writeLongLe
+import kotlinx.io.writeShortLe
+import kotlinx.io.writeString
 import net.avianlabs.solana.domain.core.AccountMeta
 import net.avianlabs.solana.domain.core.TransactionInstruction
 import net.avianlabs.solana.domain.program.Program.Companion.createTransactionInstruction
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
-import okio.Buffer
 
 public object SystemProgram : Program {
   public override val programId: PublicKey =
@@ -63,12 +68,12 @@ public object SystemProgram : Program {
       AccountMeta(payer, isSigner = true, isWritable = true),
       AccountMeta(newAccount, isSigner = true, isWritable = true),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.CreateAccount.index.toInt())
-      .writeLongLe(lamports.toLong())
-      .writeLongLe(space.toLong())
-      .write(programAddress.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.CreateAccount.index.toInt())
+      writeLongLe(lamports.toLong())
+      writeLongLe(space.toLong())
+      write(programAddress.bytes)
+    }.readByteArray(),
   )
 
   public fun assign(account: PublicKey, programAddress: PublicKey): TransactionInstruction =
@@ -77,10 +82,10 @@ public object SystemProgram : Program {
     keys = listOf(
       AccountMeta(account, isSigner = true, isWritable = true),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.Assign.index.toInt())
-      .write(programAddress.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.Assign.index.toInt())
+      write(programAddress.bytes)
+    }.readByteArray(),
   )
 
   public fun transferSol(
@@ -93,10 +98,10 @@ public object SystemProgram : Program {
       AccountMeta(source, isSigner = true, isWritable = true),
       AccountMeta(destination, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.TransferSol.index.toInt())
-      .writeLongLe(amount.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.TransferSol.index.toInt())
+      writeLongLe(amount.toLong())
+    }.readByteArray(),
   )
 
   @Deprecated(
@@ -127,18 +132,16 @@ public object SystemProgram : Program {
       AccountMeta(newAccount, isSigner = false, isWritable = true),
       AccountMeta(baseAccount, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.CreateAccountWithSeed.index.toInt())
-      .write(base.bytes)
-      .apply {
-        val bytes = seed.encodeToByteArray()
-        writeLongLe(bytes.size.toLong())
-        write(bytes)
-      }
-      .writeLongLe(amount.toLong())
-      .writeLongLe(space.toLong())
-      .write(programAddress.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.CreateAccountWithSeed.index.toInt())
+      write(base.bytes)
+      val seedBytes = seed.encodeToByteArray()
+      writeLongLe(seedBytes.size.toLong())
+      write(seedBytes)
+      writeLongLe(amount.toLong())
+      writeLongLe(space.toLong())
+      write(programAddress.bytes)
+    }.readByteArray(),
   )
 
   public fun advanceNonceAccount(
@@ -152,9 +155,9 @@ public object SystemProgram : Program {
       AccountMeta(recentBlockhashesSysvar, isSigner = false, isWritable = false),
       AccountMeta(nonceAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.AdvanceNonceAccount.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.AdvanceNonceAccount.index.toInt())
+    }.readByteArray(),
   )
 
   @Deprecated(
@@ -185,10 +188,10 @@ public object SystemProgram : Program {
       AccountMeta(rentSysvar, isSigner = false, isWritable = false),
       AccountMeta(nonceAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.WithdrawNonceAccount.index.toInt())
-      .writeLongLe(withdrawAmount.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.WithdrawNonceAccount.index.toInt())
+      writeLongLe(withdrawAmount.toLong())
+    }.readByteArray(),
   )
 
   public fun initializeNonceAccount(
@@ -203,10 +206,10 @@ public object SystemProgram : Program {
       AccountMeta(recentBlockhashesSysvar, isSigner = false, isWritable = false),
       AccountMeta(rentSysvar, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.InitializeNonceAccount.index.toInt())
-      .write(nonceAuthority.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.InitializeNonceAccount.index.toInt())
+      write(nonceAuthority.bytes)
+    }.readByteArray(),
   )
 
   @Deprecated(
@@ -233,10 +236,10 @@ public object SystemProgram : Program {
       AccountMeta(nonceAccount, isSigner = false, isWritable = true),
       AccountMeta(nonceAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.AuthorizeNonceAccount.index.toInt())
-      .write(newNonceAuthority.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.AuthorizeNonceAccount.index.toInt())
+      write(newNonceAuthority.bytes)
+    }.readByteArray(),
   )
 
   public fun allocate(newAccount: PublicKey, space: ULong): TransactionInstruction =
@@ -245,10 +248,10 @@ public object SystemProgram : Program {
     keys = listOf(
       AccountMeta(newAccount, isSigner = true, isWritable = true),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.Allocate.index.toInt())
-      .writeLongLe(space.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.Allocate.index.toInt())
+      writeLongLe(space.toLong())
+    }.readByteArray(),
   )
 
   public fun allocateWithSeed(
@@ -264,17 +267,15 @@ public object SystemProgram : Program {
       AccountMeta(newAccount, isSigner = false, isWritable = true),
       AccountMeta(baseAccount, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.AllocateWithSeed.index.toInt())
-      .write(base.bytes)
-      .apply {
-        val bytes = seed.encodeToByteArray()
-        writeLongLe(bytes.size.toLong())
-        write(bytes)
-      }
-      .writeLongLe(space.toLong())
-      .write(programAddress.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.AllocateWithSeed.index.toInt())
+      write(base.bytes)
+      val seedBytes = seed.encodeToByteArray()
+      writeLongLe(seedBytes.size.toLong())
+      write(seedBytes)
+      writeLongLe(space.toLong())
+      write(programAddress.bytes)
+    }.readByteArray(),
   )
 
   public fun assignWithSeed(
@@ -289,16 +290,14 @@ public object SystemProgram : Program {
       AccountMeta(account, isSigner = false, isWritable = true),
       AccountMeta(baseAccount, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.AssignWithSeed.index.toInt())
-      .write(base.bytes)
-      .apply {
-        val bytes = seed.encodeToByteArray()
-        writeLongLe(bytes.size.toLong())
-        write(bytes)
-      }
-      .write(programAddress.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.AssignWithSeed.index.toInt())
+      write(base.bytes)
+      val seedBytes = seed.encodeToByteArray()
+      writeLongLe(seedBytes.size.toLong())
+      write(seedBytes)
+      write(programAddress.bytes)
+    }.readByteArray(),
   )
 
   public fun transferSolWithSeed(
@@ -315,16 +314,14 @@ public object SystemProgram : Program {
       AccountMeta(baseAccount, isSigner = true, isWritable = false),
       AccountMeta(destination, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.TransferSolWithSeed.index.toInt())
-      .writeLongLe(amount.toLong())
-      .apply {
-        val bytes = fromSeed.encodeToByteArray()
-        writeLongLe(bytes.size.toLong())
-        write(bytes)
-      }
-      .write(fromOwner.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.TransferSolWithSeed.index.toInt())
+      writeLongLe(amount.toLong())
+      val fromSeedBytes = fromSeed.encodeToByteArray()
+      writeLongLe(fromSeedBytes.size.toLong())
+      write(fromSeedBytes)
+      write(fromOwner.bytes)
+    }.readByteArray(),
   )
 
   public fun upgradeNonceAccount(nonceAccount: PublicKey): TransactionInstruction =
@@ -333,9 +330,9 @@ public object SystemProgram : Program {
     keys = listOf(
       AccountMeta(nonceAccount, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeIntLe(Instruction.UpgradeNonceAccount.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeIntLe(Instruction.UpgradeNonceAccount.index.toInt())
+    }.readByteArray(),
   )
 
   public enum class NonceVersion(

--- a/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/Token2022Program.kt
+++ b/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/Token2022Program.kt
@@ -20,11 +20,16 @@ import kotlin.UShort
 import kotlin.collections.List
 import kotlin.collections.Map
 import kotlin.jvm.JvmInline
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.io.writeIntLe
+import kotlinx.io.writeLongLe
+import kotlinx.io.writeShortLe
+import kotlinx.io.writeString
 import net.avianlabs.solana.domain.core.AccountMeta
 import net.avianlabs.solana.domain.core.TransactionInstruction
 import net.avianlabs.solana.domain.program.Program.Companion.createTransactionInstruction
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
-import okio.Buffer
 
 public object Token2022Program : TokenProgram() {
   public override val programId: PublicKey =
@@ -58,19 +63,17 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(rent, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeMint.index.toInt())
-      .writeByte(decimals.toInt())
-      .write(mintAuthority.bytes)
-      .apply {
-        if (freezeAuthority != null) {
-          writeByte(1)
-          .write(freezeAuthority.bytes)
-        } else {
-          writeByte(0)
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeMint.index.toByte())
+      writeByte(decimals.toByte())
+      write(mintAuthority.bytes)
+      if (freezeAuthority != null) {
+        writeByte(1.toByte())
+        write(freezeAuthority.bytes)
+      } else {
+        writeByte(0.toByte())
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -98,9 +101,9 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(owner, isSigner = false, isWritable = false),
       AccountMeta(rent, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeAccount.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeAccount.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -126,10 +129,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(multisig, isSigner = false, isWritable = true),
       AccountMeta(rent, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeMultisig.index.toInt())
-      .writeByte(m.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeMultisig.index.toByte())
+      writeByte(m.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -149,10 +152,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(destination, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.Transfer.index.toInt())
-      .writeLongLe(amount.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.Transfer.index.toByte())
+      writeLongLe(amount.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -171,10 +174,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(delegate, isSigner = false, isWritable = false),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.Approve.index.toInt())
-      .writeLongLe(amount.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.Approve.index.toByte())
+      writeLongLe(amount.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -187,9 +190,9 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(source, isSigner = false, isWritable = true),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.Revoke.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.Revoke.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -206,18 +209,16 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(owned, isSigner = false, isWritable = true),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.SetAuthority.index.toInt())
-      .writeByte(authorityType.value.toInt())
-      .apply {
-        if (newAuthority != null) {
-          writeByte(1)
-          .write(newAuthority.bytes)
-        } else {
-          writeByte(0)
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.SetAuthority.index.toByte())
+      writeByte(authorityType.value.toByte())
+      if (newAuthority != null) {
+        writeByte(1.toByte())
+        write(newAuthority.bytes)
+      } else {
+        writeByte(0.toByte())
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -235,10 +236,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(mintAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.MintTo.index.toInt())
-      .writeLongLe(amount.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.MintTo.index.toByte())
+      writeLongLe(amount.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -257,10 +258,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.Burn.index.toInt())
-      .writeLongLe(amount.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.Burn.index.toByte())
+      writeLongLe(amount.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -278,9 +279,9 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(destination, isSigner = false, isWritable = true),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.CloseAccount.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.CloseAccount.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -297,9 +298,9 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = false),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.FreezeAccount.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.FreezeAccount.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -316,9 +317,9 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = false),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ThawAccount.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ThawAccount.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -345,11 +346,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(destination, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.TransferChecked.index.toInt())
-      .writeLongLe(amount.toLong())
-      .writeByte(decimals.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.TransferChecked.index.toByte())
+      writeLongLe(amount.toLong())
+      writeByte(decimals.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -375,11 +376,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(delegate, isSigner = false, isWritable = false),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ApproveChecked.index.toInt())
-      .writeLongLe(amount.toLong())
-      .writeByte(decimals.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ApproveChecked.index.toByte())
+      writeLongLe(amount.toLong())
+      writeByte(decimals.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -402,11 +403,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(mintAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.MintToChecked.index.toInt())
-      .writeLongLe(amount.toLong())
-      .writeByte(decimals.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.MintToChecked.index.toByte())
+      writeLongLe(amount.toLong())
+      writeByte(decimals.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -430,11 +431,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.BurnChecked.index.toInt())
-      .writeLongLe(amount.toLong())
-      .writeByte(decimals.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.BurnChecked.index.toByte())
+      writeLongLe(amount.toLong())
+      writeByte(decimals.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -455,10 +456,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = false),
       AccountMeta(rent, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeAccount2.index.toInt())
-      .write(owner.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeAccount2.index.toByte())
+      write(owner.bytes)
+    }.readByteArray(),
   )
 
   /**
@@ -474,9 +475,9 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(account, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.SyncNative.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.SyncNative.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -492,10 +493,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(account, isSigner = false, isWritable = true),
       AccountMeta(mint, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeAccount3.index.toInt())
-      .write(owner.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeAccount3.index.toByte())
+      write(owner.bytes)
+    }.readByteArray(),
   )
 
   /**
@@ -507,10 +508,10 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(multisig, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeMultisig2.index.toInt())
-      .writeByte(m.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeMultisig2.index.toByte())
+      writeByte(m.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -526,19 +527,17 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeMint2.index.toInt())
-      .writeByte(decimals.toInt())
-      .write(mintAuthority.bytes)
-      .apply {
-        if (freezeAuthority != null) {
-          writeByte(1)
-          .write(freezeAuthority.bytes)
-        } else {
-          writeByte(0)
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeMint2.index.toByte())
+      writeByte(decimals.toByte())
+      write(mintAuthority.bytes)
+      if (freezeAuthority != null) {
+        writeByte(1.toByte())
+        write(freezeAuthority.bytes)
+      } else {
+        writeByte(0.toByte())
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -554,9 +553,9 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.GetAccountDataSize.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.GetAccountDataSize.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -574,9 +573,9 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(account, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeImmutableOwner.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeImmutableOwner.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -595,10 +594,10 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.AmountToUiAmount.index.toInt())
-      .writeLongLe(amount.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.AmountToUiAmount.index.toByte())
+      writeLongLe(amount.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -615,10 +614,10 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UiAmountToAmount.index.toInt())
-      .writeUtf8(uiAmount)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.UiAmountToAmount.index.toByte())
+      writeString(uiAmount)
+    }.readByteArray(),
   )
 
   /**
@@ -636,17 +635,15 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeMintCloseAuthority.index.toInt())
-      .apply {
-        if (closeAuthority != null) {
-          writeByte(1)
-          .write(closeAuthority.bytes)
-        } else {
-          writeByte(0)
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeMintCloseAuthority.index.toByte())
+      if (closeAuthority != null) {
+        writeByte(1.toByte())
+        write(closeAuthority.bytes)
+      } else {
+        writeByte(0.toByte())
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -669,28 +666,24 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeTransferFeeConfig.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (transferFeeConfigAuthority != null) {
-          writeByte(1)
-          .write(transferFeeConfigAuthority.bytes)
-        } else {
-          writeByte(0)
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeTransferFeeConfig.index.toByte())
+      writeByte(0.toByte())
+      if (transferFeeConfigAuthority != null) {
+        writeByte(1.toByte())
+        write(transferFeeConfigAuthority.bytes)
+      } else {
+        writeByte(0.toByte())
       }
-      .apply {
-        if (withdrawWithheldAuthority != null) {
-          writeByte(1)
-          .write(withdrawWithheldAuthority.bytes)
-        } else {
-          writeByte(0)
-        }
+      if (withdrawWithheldAuthority != null) {
+        writeByte(1.toByte())
+        write(withdrawWithheldAuthority.bytes)
+      } else {
+        writeByte(0.toByte())
       }
-      .writeShortLe(transferFeeBasisPoints.toInt())
-      .writeLongLe(maximumFee.toLong())
-      .readByteArray(),
+      writeShortLe(transferFeeBasisPoints.toShort())
+      writeLongLe(maximumFee.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -716,13 +709,13 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(destination, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.TransferCheckedWithFee.index.toInt())
-      .writeByte(1)
-      .writeLongLe(amount.toLong())
-      .writeByte(decimals.toInt())
-      .writeLongLe(fee.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.TransferCheckedWithFee.index.toByte())
+      writeByte(1.toByte())
+      writeLongLe(amount.toLong())
+      writeByte(decimals.toByte())
+      writeLongLe(fee.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -740,10 +733,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(feeReceiver, isSigner = false, isWritable = true),
       AccountMeta(withdrawWithheldAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.WithdrawWithheldTokensFromMint.index.toInt())
-      .writeByte(2)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.WithdrawWithheldTokensFromMint.index.toByte())
+      writeByte(2.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -762,11 +755,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(feeReceiver, isSigner = false, isWritable = true),
       AccountMeta(withdrawWithheldAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.WithdrawWithheldTokensFromAccounts.index.toInt())
-      .writeByte(3)
-      .writeByte(numTokenAccounts.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.WithdrawWithheldTokensFromAccounts.index.toByte())
+      writeByte(3.toByte())
+      writeByte(numTokenAccounts.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -783,10 +776,10 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.HarvestWithheldTokensToMint.index.toInt())
-      .writeByte(4)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.HarvestWithheldTokensToMint.index.toByte())
+      writeByte(4.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -804,12 +797,12 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(transferFeeConfigAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.SetTransferFee.index.toInt())
-      .writeByte(5)
-      .writeShortLe(transferFeeBasisPoints.toInt())
-      .writeLongLe(maximumFee.toLong())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.SetTransferFee.index.toByte())
+      writeByte(5.toByte())
+      writeShortLe(transferFeeBasisPoints.toShort())
+      writeLongLe(maximumFee.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -833,25 +826,21 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeConfidentialTransferMint.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (authority != null) {
-          write(authority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeConfidentialTransferMint.index.toByte())
+      writeByte(0.toByte())
+      if (authority != null) {
+        write(authority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .writeByte(if (autoApproveNewAccounts) 1 else 0)
-      .apply {
-        if (auditorElgamalPubkey != null) {
-          write(auditorElgamalPubkey.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      writeByte((if (autoApproveNewAccounts) 1 else 0).toByte())
+      if (auditorElgamalPubkey != null) {
+        write(auditorElgamalPubkey.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -871,18 +860,16 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UpdateConfidentialTransferMint.index.toInt())
-      .writeByte(1)
-      .writeByte(if (autoApproveNewAccounts) 1 else 0)
-      .apply {
-        if (auditorElgamalPubkey != null) {
-          write(auditorElgamalPubkey.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.UpdateConfidentialTransferMint.index.toByte())
+      writeByte(1.toByte())
+      writeByte((if (autoApproveNewAccounts) 1 else 0).toByte())
+      if (auditorElgamalPubkey != null) {
+        write(auditorElgamalPubkey.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -922,13 +909,13 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(record, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ConfigureConfidentialTransferAccount.index.toInt())
-      .writeByte(2)
-      .write(decryptableZeroBalance.bytes)
-      .writeLongLe(maximumPendingBalanceCreditCounter.toLong())
-      .writeByte(proofInstructionOffset.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ConfigureConfidentialTransferAccount.index.toByte())
+      writeByte(2.toByte())
+      write(decryptableZeroBalance.bytes)
+      writeLongLe(maximumPendingBalanceCreditCounter.toLong())
+      writeByte(proofInstructionOffset)
+    }.readByteArray(),
   )
 
   /**
@@ -951,10 +938,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ApproveConfidentialTransferAccount.index.toInt())
-      .writeByte(3)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ApproveConfidentialTransferAccount.index.toByte())
+      writeByte(3.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -992,11 +979,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(record, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.EmptyConfidentialTransferAccount.index.toInt())
-      .writeByte(4)
-      .writeByte(proofInstructionOffset.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.EmptyConfidentialTransferAccount.index.toByte())
+      writeByte(4.toByte())
+      writeByte(proofInstructionOffset)
+    }.readByteArray(),
   )
 
   /**
@@ -1023,12 +1010,12 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ConfidentialDeposit.index.toInt())
-      .writeByte(5)
-      .writeLongLe(amount.toLong())
-      .writeByte(decimals.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ConfidentialDeposit.index.toByte())
+      writeByte(5.toByte())
+      writeLongLe(amount.toLong())
+      writeByte(decimals.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1069,15 +1056,15 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(rangeRecord, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ConfidentialWithdraw.index.toInt())
-      .writeByte(6)
-      .writeLongLe(amount.toLong())
-      .writeByte(decimals.toInt())
-      .write(newDecryptableAvailableBalance.bytes)
-      .writeByte(equalityProofInstructionOffset.toInt())
-      .writeByte(rangeProofInstructionOffset.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ConfidentialWithdraw.index.toByte())
+      writeByte(6.toByte())
+      writeLongLe(amount.toLong())
+      writeByte(decimals.toByte())
+      write(newDecryptableAvailableBalance.bytes)
+      writeByte(equalityProofInstructionOffset)
+      writeByte(rangeProofInstructionOffset)
+    }.readByteArray(),
   )
 
   /**
@@ -1120,14 +1107,14 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(rangeRecord, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ConfidentialTransfer.index.toInt())
-      .writeByte(7)
-      .write(newSourceDecryptableAvailableBalance.bytes)
-      .writeByte(equalityProofInstructionOffset.toInt())
-      .writeByte(ciphertextValidityProofInstructionOffset.toInt())
-      .writeByte(rangeProofInstructionOffset.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ConfidentialTransfer.index.toByte())
+      writeByte(7.toByte())
+      write(newSourceDecryptableAvailableBalance.bytes)
+      writeByte(equalityProofInstructionOffset)
+      writeByte(ciphertextValidityProofInstructionOffset)
+      writeByte(rangeProofInstructionOffset)
+    }.readByteArray(),
   )
 
   /**
@@ -1154,12 +1141,12 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ApplyConfidentialPendingBalance.index.toInt())
-      .writeByte(8)
-      .writeLongLe(expectedPendingBalanceCreditCounter.toLong())
-      .write(newDecryptableAvailableBalance.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ApplyConfidentialPendingBalance.index.toByte())
+      writeByte(8.toByte())
+      writeLongLe(expectedPendingBalanceCreditCounter.toLong())
+      write(newDecryptableAvailableBalance.bytes)
+    }.readByteArray(),
   )
 
   /**
@@ -1173,10 +1160,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.EnableConfidentialCredits.index.toInt())
-      .writeByte(9)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.EnableConfidentialCredits.index.toByte())
+      writeByte(9.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1196,10 +1183,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.DisableConfidentialCredits.index.toInt())
-      .writeByte(10)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.DisableConfidentialCredits.index.toByte())
+      writeByte(10.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1213,10 +1200,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.EnableNonConfidentialCredits.index.toInt())
-      .writeByte(11)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.EnableNonConfidentialCredits.index.toByte())
+      writeByte(11.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1233,10 +1220,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.DisableNonConfidentialCredits.index.toInt())
-      .writeByte(12)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.DisableNonConfidentialCredits.index.toByte())
+      writeByte(12.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1290,16 +1277,16 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(rangeRecord, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.ConfidentialTransferWithFee.index.toInt())
-      .writeByte(13)
-      .write(newSourceDecryptableAvailableBalance.bytes)
-      .writeByte(equalityProofInstructionOffset.toInt())
-      .writeByte(transferAmountCiphertextValidityProofInstructionOffset.toInt())
-      .writeByte(feeSigmaProofInstructionOffset.toInt())
-      .writeByte(feeCiphertextValidityProofInstructionOffset.toInt())
-      .writeByte(rangeProofInstructionOffset.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.ConfidentialTransferWithFee.index.toByte())
+      writeByte(13.toByte())
+      write(newSourceDecryptableAvailableBalance.bytes)
+      writeByte(equalityProofInstructionOffset)
+      writeByte(transferAmountCiphertextValidityProofInstructionOffset)
+      writeByte(feeSigmaProofInstructionOffset)
+      writeByte(feeCiphertextValidityProofInstructionOffset)
+      writeByte(rangeProofInstructionOffset)
+    }.readByteArray(),
   )
 
   /**
@@ -1318,11 +1305,11 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeDefaultAccountState.index.toInt())
-      .writeByte(0)
-      .writeByte(state.value.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeDefaultAccountState.index.toByte())
+      writeByte(0.toByte())
+      writeByte(state.value.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1339,11 +1326,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(freezeAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UpdateDefaultAccountState.index.toInt())
-      .writeByte(1)
-      .writeByte(state.value.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.UpdateDefaultAccountState.index.toByte())
+      writeByte(1.toByte())
+      writeByte(state.value.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1365,14 +1352,12 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(systemProgram, isSigner = false, isWritable = false),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.Reallocate.index.toInt())
-      .apply {
-        newExtensionTypes.forEach { item ->
-          writeShortLe(item.value.toInt())
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.Reallocate.index.toByte())
+      newExtensionTypes.forEach { item ->
+        writeShortLe(item.value.toShort())
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -1386,10 +1371,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.EnableMemoTransfers.index.toInt())
-      .writeByte(0)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.EnableMemoTransfers.index.toByte())
+      writeByte(0.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1405,10 +1390,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.DisableMemoTransfers.index.toInt())
-      .writeByte(1)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.DisableMemoTransfers.index.toByte())
+      writeByte(1.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1429,9 +1414,9 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(nativeMint, isSigner = false, isWritable = true),
       AccountMeta(systemProgram, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.CreateNativeMint.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.CreateNativeMint.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1445,9 +1430,9 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeNonTransferableMint.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeNonTransferableMint.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1469,18 +1454,16 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeInterestBearingMint.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (rateAuthority != null) {
-          write(rateAuthority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeInterestBearingMint.index.toByte())
+      writeByte(0.toByte())
+      if (rateAuthority != null) {
+        write(rateAuthority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .writeShortLe(rate.toInt())
-      .readByteArray(),
+      writeShortLe(rate)
+    }.readByteArray(),
   )
 
   /**
@@ -1497,11 +1480,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(rateAuthority, isSigner = true, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UpdateRateInterestBearingMint.index.toInt())
-      .writeByte(1)
-      .writeShortLe(rate.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.UpdateRateInterestBearingMint.index.toByte())
+      writeByte(1.toByte())
+      writeShortLe(rate)
+    }.readByteArray(),
   )
 
   /**
@@ -1520,10 +1503,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.EnableCpiGuard.index.toInt())
-      .writeByte(0)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.EnableCpiGuard.index.toByte())
+      writeByte(0.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1538,10 +1521,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(token, isSigner = false, isWritable = true),
       AccountMeta(owner, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.DisableCpiGuard.index.toInt())
-      .writeByte(1)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.DisableCpiGuard.index.toByte())
+      writeByte(1.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1559,10 +1542,10 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializePermanentDelegate.index.toInt())
-      .write(delegate.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.InitializePermanentDelegate.index.toByte())
+      write(delegate.bytes)
+    }.readByteArray(),
   )
 
   /**
@@ -1583,24 +1566,20 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeTransferHook.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (authority != null) {
-          write(authority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeTransferHook.index.toByte())
+      writeByte(0.toByte())
+      if (authority != null) {
+        write(authority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .apply {
-        if (targetProgramId != null) {
-          write(targetProgramId.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      if (targetProgramId != null) {
+        write(targetProgramId.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -1622,17 +1601,15 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UpdateTransferHook.index.toInt())
-      .writeByte(1)
-      .apply {
-        if (targetProgramId != null) {
-          write(targetProgramId.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.UpdateTransferHook.index.toByte())
+      writeByte(1.toByte())
+      if (targetProgramId != null) {
+        write(targetProgramId.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -1653,24 +1630,20 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeConfidentialTransferFee.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (authority != null) {
-          write(authority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeConfidentialTransferFee.index.toByte())
+      writeByte(0.toByte())
+      if (authority != null) {
+        write(authority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .apply {
-        if (withdrawWithheldAuthorityElGamalPubkey != null) {
-          write(withdrawWithheldAuthorityElGamalPubkey.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      if (withdrawWithheldAuthorityElGamalPubkey != null) {
+        write(withdrawWithheldAuthorityElGamalPubkey.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -1701,12 +1674,12 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(record, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee.index.toInt())
-      .writeByte(1)
-      .writeByte(proofInstructionOffset.toInt())
-      .write(newDecryptableAvailableBalance.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.WithdrawWithheldTokensFromMintForConfidentialTransferFee.index.toByte())
+      writeByte(1.toByte())
+      writeByte(proofInstructionOffset)
+      write(newDecryptableAvailableBalance.bytes)
+    }.readByteArray(),
   )
 
   /**
@@ -1734,13 +1707,13 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(record, isSigner = false, isWritable = false),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee.index.toInt())
-      .writeByte(2)
-      .writeByte(numTokenAccounts.toInt())
-      .writeByte(proofInstructionOffset.toInt())
-      .write(newDecryptableAvailableBalance.bytes)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.WithdrawWithheldTokensFromAccountsForConfidentialTransferFee.index.toByte())
+      writeByte(2.toByte())
+      writeByte(numTokenAccounts.toByte())
+      writeByte(proofInstructionOffset)
+      write(newDecryptableAvailableBalance.bytes)
+    }.readByteArray(),
   )
 
   /**
@@ -1757,10 +1730,10 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee.index.toInt())
-      .writeByte(3)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.HarvestWithheldTokensToMintForConfidentialTransferFee.index.toByte())
+      writeByte(3.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1773,10 +1746,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.EnableHarvestToMint.index.toInt())
-      .writeByte(4)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.EnableHarvestToMint.index.toByte())
+      writeByte(4.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1789,10 +1762,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.DisableHarvestToMint.index.toInt())
-      .writeByte(5)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.DisableHarvestToMint.index.toByte())
+      writeByte(5.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1811,9 +1784,9 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(destinationAccount, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.WithdrawExcessLamports.index.toInt())
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.WithdrawExcessLamports.index.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -1835,24 +1808,20 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeMetadataPointer.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (authority != null) {
-          write(authority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeMetadataPointer.index.toByte())
+      writeByte(0.toByte())
+      if (authority != null) {
+        write(authority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .apply {
-        if (metadataAddress != null) {
-          write(metadataAddress.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      if (metadataAddress != null) {
+        write(metadataAddress.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -1869,17 +1838,15 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(metadataPointerAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UpdateMetadataPointer.index.toInt())
-      .writeByte(1)
-      .apply {
-        if (metadataAddress != null) {
-          write(metadataAddress.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.UpdateMetadataPointer.index.toByte())
+      writeByte(1.toByte())
+      if (metadataAddress != null) {
+        write(metadataAddress.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -1901,24 +1868,20 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeGroupPointer.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (authority != null) {
-          write(authority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeGroupPointer.index.toByte())
+      writeByte(0.toByte())
+      if (authority != null) {
+        write(authority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .apply {
-        if (groupAddress != null) {
-          write(groupAddress.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      if (groupAddress != null) {
+        write(groupAddress.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -1935,17 +1898,15 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(groupPointerAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UpdateGroupPointer.index.toInt())
-      .writeByte(1)
-      .apply {
-        if (groupAddress != null) {
-          write(groupAddress.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.UpdateGroupPointer.index.toByte())
+      writeByte(1.toByte())
+      if (groupAddress != null) {
+        write(groupAddress.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -1967,24 +1928,20 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeGroupMemberPointer.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (authority != null) {
-          write(authority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeGroupMemberPointer.index.toByte())
+      writeByte(0.toByte())
+      if (authority != null) {
+        write(authority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .apply {
-        if (memberAddress != null) {
-          write(memberAddress.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      if (memberAddress != null) {
+        write(memberAddress.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -2001,17 +1958,15 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(groupMemberPointerAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UpdateGroupMemberPointer.index.toInt())
-      .writeByte(1)
-      .apply {
-        if (memberAddress != null) {
-          write(memberAddress.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.UpdateGroupMemberPointer.index.toByte())
+      writeByte(1.toByte())
+      if (memberAddress != null) {
+        write(memberAddress.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -2032,18 +1987,16 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializeScaledUiAmountMint.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (authority != null) {
-          write(authority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializeScaledUiAmountMint.index.toByte())
+      writeByte(0.toByte())
+      if (authority != null) {
+        write(authority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .writeLongLe(multiplier.toRawBits())
-      .readByteArray(),
+      writeLongLe(multiplier.toRawBits())
+    }.readByteArray(),
   )
 
   /**
@@ -2062,12 +2015,12 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UpdateMultiplierScaledUiMint.index.toInt())
-      .writeByte(1)
-      .writeLongLe(multiplier.toRawBits())
-      .writeLongLe(effectiveTimestamp)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.UpdateMultiplierScaledUiMint.index.toByte())
+      writeByte(1.toByte())
+      writeLongLe(multiplier.toRawBits())
+      writeLongLe(effectiveTimestamp)
+    }.readByteArray(),
   )
 
   /**
@@ -2081,17 +2034,15 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(mint, isSigner = false, isWritable = true),
     ),
-    data = Buffer()
-      .writeByte(Instruction.InitializePausableConfig.index.toInt())
-      .writeByte(0)
-      .apply {
-        if (authority != null) {
-          write(authority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.InitializePausableConfig.index.toByte())
+      writeByte(0.toByte())
+      if (authority != null) {
+        write(authority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -2106,10 +2057,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.Pause.index.toInt())
-      .writeByte(1)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.Pause.index.toByte())
+      writeByte(1.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -2124,10 +2075,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.Resume.index.toInt())
-      .writeByte(2)
-      .readByteArray(),
+    data = Buffer().apply {
+      writeByte(Instruction.Resume.index.toByte())
+      writeByte(2.toByte())
+    }.readByteArray(),
   )
 
   /**
@@ -2153,25 +2104,19 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = false),
       AccountMeta(mintAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0xd2.toByte(), 0xe1.toByte(), 0x1e.toByte(), 0xa2.toByte(), 0x58.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0xd2.toByte(), 0xe1.toByte(), 0x1e.toByte(), 0xa2.toByte(), 0x58.toByte(),
           0xb8.toByte(), 0x4d.toByte(), 0x8d.toByte()))
-      .apply {
-        val bytes = name.encodeToByteArray()
-        writeIntLe(bytes.size)
-        write(bytes)
-      }
-      .apply {
-        val bytes = symbol.encodeToByteArray()
-        writeIntLe(bytes.size)
-        write(bytes)
-      }
-      .apply {
-        val bytes = uri.encodeToByteArray()
-        writeIntLe(bytes.size)
-        write(bytes)
-      }
-      .readByteArray(),
+      val nameBytes = name.encodeToByteArray()
+      writeIntLe(nameBytes.size)
+      write(nameBytes)
+      val symbolBytes = symbol.encodeToByteArray()
+      writeIntLe(symbolBytes.size)
+      write(symbolBytes)
+      val uriBytes = uri.encodeToByteArray()
+      writeIntLe(uriBytes.size)
+      write(uriBytes)
+    }.readByteArray(),
   )
 
   /**
@@ -2199,16 +2144,14 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(metadata, isSigner = false, isWritable = true),
       AccountMeta(updateAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0xdd.toByte(), 0xe9.toByte(), 0x31.toByte(), 0x2d.toByte(), 0xb5.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0xdd.toByte(), 0xe9.toByte(), 0x31.toByte(), 0x2d.toByte(), 0xb5.toByte(),
           0xca.toByte(), 0xdc.toByte(), 0xc8.toByte()))
-      .write(field.serialize())
-      .apply {
-        val bytes = value.encodeToByteArray()
-        writeIntLe(bytes.size)
-        write(bytes)
-      }
-      .readByteArray(),
+      write(field.serialize())
+      val valueBytes = value.encodeToByteArray()
+      writeIntLe(valueBytes.size)
+      write(valueBytes)
+    }.readByteArray(),
   )
 
   /**
@@ -2231,16 +2174,14 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(metadata, isSigner = false, isWritable = true),
       AccountMeta(updateAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0xea.toByte(), 0x12.toByte(), 0x20.toByte(), 0x38.toByte(), 0x59.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0xea.toByte(), 0x12.toByte(), 0x20.toByte(), 0x38.toByte(), 0x59.toByte(),
           0x8d.toByte(), 0x25.toByte(), 0xb5.toByte()))
-      .writeByte(if (idempotent) 1 else 0)
-      .apply {
-        val bytes = key.encodeToByteArray()
-        writeIntLe(bytes.size)
-        write(bytes)
-      }
-      .readByteArray(),
+      writeByte((if (idempotent) 1 else 0).toByte())
+      val keyBytes = key.encodeToByteArray()
+      writeIntLe(keyBytes.size)
+      write(keyBytes)
+    }.readByteArray(),
   )
 
   /**
@@ -2256,17 +2197,15 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(metadata, isSigner = false, isWritable = true),
       AccountMeta(updateAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0xd7.toByte(), 0xe4.toByte(), 0xa6.toByte(), 0xe4.toByte(), 0x54.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0xd7.toByte(), 0xe4.toByte(), 0xa6.toByte(), 0xe4.toByte(), 0x54.toByte(),
           0x64.toByte(), 0x56.toByte(), 0x7b.toByte()))
-      .apply {
-        if (newUpdateAuthority != null) {
-          write(newUpdateAuthority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      if (newUpdateAuthority != null) {
+        write(newUpdateAuthority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -2289,26 +2228,22 @@ public object Token2022Program : TokenProgram() {
     keys = listOf(
       AccountMeta(metadata, isSigner = false, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0xfa.toByte(), 0xa6.toByte(), 0xb4.toByte(), 0xfa.toByte(), 0x0d.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0xfa.toByte(), 0xa6.toByte(), 0xb4.toByte(), 0xfa.toByte(), 0x0d.toByte(),
           0x0c.toByte(), 0xb8.toByte(), 0x46.toByte()))
-      .apply {
-        if (start != null) {
-          writeByte(1)
-          .writeLongLe(start.toLong())
-        } else {
-          writeByte(0)
-        }
+      if (start != null) {
+        writeByte(1.toByte())
+        writeLongLe(start.toLong())
+      } else {
+        writeByte(0.toByte())
       }
-      .apply {
-        if (end != null) {
-          writeByte(1)
-          .writeLongLe(end.toLong())
-        } else {
-          writeByte(0)
-        }
+      if (end != null) {
+        writeByte(1.toByte())
+        writeLongLe(end.toLong())
+      } else {
+        writeByte(0.toByte())
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -2329,18 +2264,16 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(mint, isSigner = false, isWritable = false),
       AccountMeta(mintAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0x79.toByte(), 0x71.toByte(), 0x6c.toByte(), 0x27.toByte(), 0x36.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0x79.toByte(), 0x71.toByte(), 0x6c.toByte(), 0x27.toByte(), 0x36.toByte(),
           0x33.toByte(), 0x00.toByte(), 0x04.toByte()))
-      .apply {
-        if (updateAuthority != null) {
-          write(updateAuthority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      if (updateAuthority != null) {
+        write(updateAuthority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .writeLongLe(maxSize.toLong())
-      .readByteArray(),
+      writeLongLe(maxSize.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -2356,11 +2289,11 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(group, isSigner = false, isWritable = true),
       AccountMeta(updateAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0x6c.toByte(), 0x25.toByte(), 0xab.toByte(), 0x8f.toByte(), 0xf8.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0x6c.toByte(), 0x25.toByte(), 0xab.toByte(), 0x8f.toByte(), 0xf8.toByte(),
           0x1e.toByte(), 0x12.toByte(), 0x6e.toByte()))
-      .writeLongLe(maxSize.toLong())
-      .readByteArray(),
+      writeLongLe(maxSize.toLong())
+    }.readByteArray(),
   )
 
   /**
@@ -2376,17 +2309,15 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(group, isSigner = false, isWritable = true),
       AccountMeta(updateAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0xa1.toByte(), 0x69.toByte(), 0x58.toByte(), 0x01.toByte(), 0xed.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0xa1.toByte(), 0x69.toByte(), 0x58.toByte(), 0x01.toByte(), 0xed.toByte(),
           0xdd.toByte(), 0xd8.toByte(), 0xcb.toByte()))
-      .apply {
-        if (newUpdateAuthority != null) {
-          write(newUpdateAuthority.bytes)
-        } else {
-          write(ByteArray(32))
-        }
+      if (newUpdateAuthority != null) {
+        write(newUpdateAuthority.bytes)
+      } else {
+        write(ByteArray(32))
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -2410,10 +2341,10 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(group, isSigner = false, isWritable = true),
       AccountMeta(groupUpdateAuthority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .write(byteArrayOf(0x98.toByte(), 0x20.toByte(), 0xde.toByte(), 0xb0.toByte(), 0xdf.toByte(),
+    data = Buffer().apply {
+      write(byteArrayOf(0x98.toByte(), 0x20.toByte(), 0xde.toByte(), 0xb0.toByte(), 0xdf.toByte(),
           0xed.toByte(), 0x74.toByte(), 0x86.toByte()))
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   /**
@@ -2431,17 +2362,15 @@ public object Token2022Program : TokenProgram() {
       AccountMeta(destination, isSigner = false, isWritable = true),
       AccountMeta(authority, isSigner = true, isWritable = false),
     ),
-    data = Buffer()
-      .writeByte(Instruction.UnwrapLamports.index.toInt())
-      .apply {
-        if (amount != null) {
-          writeByte(1)
-          .writeLongLe(amount.toLong())
-        } else {
-          writeByte(0)
-        }
+    data = Buffer().apply {
+      writeByte(Instruction.UnwrapLamports.index.toByte())
+      if (amount != null) {
+        writeByte(1.toByte())
+        writeLongLe(amount.toLong())
+      } else {
+        writeByte(0.toByte())
       }
-      .readByteArray(),
+    }.readByteArray(),
   )
 
   public enum class AccountState(
@@ -2485,7 +2414,7 @@ public object Token2022Program : TokenProgram() {
       val buffer = Buffer()
       buffer.writeLongLe(epoch.toLong())
       buffer.writeLongLe(maximumFee.toLong())
-      buffer.writeShortLe(transferFeeBasisPoints.toInt())
+      buffer.writeShortLe(transferFeeBasisPoints.toShort())
       return buffer.readByteArray()
     }
   }
@@ -2514,7 +2443,7 @@ public object Token2022Program : TokenProgram() {
     public object Uninitialized : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(0)
+        buffer.writeShortLe(0.toShort())
         return buffer.readByteArray()
       }
     }
@@ -2528,7 +2457,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(1)
+        buffer.writeShortLe(1.toShort())
         buffer.write(transferFeeConfigAuthority.bytes)
         buffer.write(withdrawWithheldAuthority.bytes)
         buffer.writeLongLe(withheldAmount.toLong())
@@ -2543,7 +2472,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(2)
+        buffer.writeShortLe(2.toShort())
         buffer.writeLongLe(withheldAmount.toLong())
         return buffer.readByteArray()
       }
@@ -2554,7 +2483,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(3)
+        buffer.writeShortLe(3.toShort())
         buffer.write(closeAuthority.bytes)
         return buffer.readByteArray()
       }
@@ -2567,13 +2496,13 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(4)
+        buffer.writeShortLe(4.toShort())
         if (authority != null) {
           buffer.write(authority.bytes)
         } else {
           buffer.write(ByteArray(32))
         }
-        buffer.writeByte(if (autoApproveNewAccounts) 1 else 0)
+        buffer.writeByte((if (autoApproveNewAccounts) 1 else 0).toByte())
         if (auditorElgamalPubkey != null) {
           buffer.write(auditorElgamalPubkey.bytes)
         } else {
@@ -2599,15 +2528,15 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(5)
-        buffer.writeByte(if (approved) 1 else 0)
+        buffer.writeShortLe(5.toShort())
+        buffer.writeByte((if (approved) 1 else 0).toByte())
         buffer.write(elgamalPubkey.bytes)
         buffer.write(pendingBalanceLow.bytes)
         buffer.write(pendingBalanceHigh.bytes)
         buffer.write(availableBalance.bytes)
         buffer.write(decryptableAvailableBalance.bytes)
-        buffer.writeByte(if (allowConfidentialCredits) 1 else 0)
-        buffer.writeByte(if (allowNonConfidentialCredits) 1 else 0)
+        buffer.writeByte((if (allowConfidentialCredits) 1 else 0).toByte())
+        buffer.writeByte((if (allowNonConfidentialCredits) 1 else 0).toByte())
         buffer.writeLongLe(pendingBalanceCreditCounter.toLong())
         buffer.writeLongLe(maximumPendingBalanceCreditCounter.toLong())
         buffer.writeLongLe(expectedPendingBalanceCreditCounter.toLong())
@@ -2621,8 +2550,8 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(6)
-        buffer.writeByte(state.value.toInt())
+        buffer.writeShortLe(6.toShort())
+        buffer.writeByte(state.value.toByte())
         return buffer.readByteArray()
       }
     }
@@ -2630,7 +2559,7 @@ public object Token2022Program : TokenProgram() {
     public object ImmutableOwner : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(7)
+        buffer.writeShortLe(7.toShort())
         return buffer.readByteArray()
       }
     }
@@ -2640,8 +2569,8 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(8)
-        buffer.writeByte(if (requireIncomingTransferMemos) 1 else 0)
+        buffer.writeShortLe(8.toShort())
+        buffer.writeByte((if (requireIncomingTransferMemos) 1 else 0).toByte())
         return buffer.readByteArray()
       }
     }
@@ -2649,7 +2578,7 @@ public object Token2022Program : TokenProgram() {
     public object NonTransferable : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(9)
+        buffer.writeShortLe(9.toShort())
         return buffer.readByteArray()
       }
     }
@@ -2663,12 +2592,12 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(10)
+        buffer.writeShortLe(10.toShort())
         buffer.write(rateAuthority.bytes)
         buffer.writeLongLe(initializationTimestamp.toLong())
-        buffer.writeShortLe(preUpdateAverageRate.toInt())
+        buffer.writeShortLe(preUpdateAverageRate)
         buffer.writeLongLe(lastUpdateTimestamp.toLong())
-        buffer.writeShortLe(currentRate.toInt())
+        buffer.writeShortLe(currentRate)
         return buffer.readByteArray()
       }
     }
@@ -2678,8 +2607,8 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(11)
-        buffer.writeByte(if (lockCpi) 1 else 0)
+        buffer.writeShortLe(11.toShort())
+        buffer.writeByte((if (lockCpi) 1 else 0).toByte())
         return buffer.readByteArray()
       }
     }
@@ -2689,7 +2618,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(12)
+        buffer.writeShortLe(12.toShort())
         buffer.write(delegate.bytes)
         return buffer.readByteArray()
       }
@@ -2698,7 +2627,7 @@ public object Token2022Program : TokenProgram() {
     public object NonTransferableAccount : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(13)
+        buffer.writeShortLe(13.toShort())
         return buffer.readByteArray()
       }
     }
@@ -2709,7 +2638,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(14)
+        buffer.writeShortLe(14.toShort())
         buffer.write(authority.bytes)
         buffer.write(programId.bytes)
         return buffer.readByteArray()
@@ -2721,8 +2650,8 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(15)
-        buffer.writeByte(if (transferring) 1 else 0)
+        buffer.writeShortLe(15.toShort())
+        buffer.writeByte((if (transferring) 1 else 0).toByte())
         return buffer.readByteArray()
       }
     }
@@ -2735,14 +2664,14 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(16)
+        buffer.writeShortLe(16.toShort())
         if (authority != null) {
           buffer.write(authority.bytes)
         } else {
           buffer.write(ByteArray(32))
         }
         buffer.write(elgamalPubkey.bytes)
-        buffer.writeByte(if (harvestToMintEnabled) 1 else 0)
+        buffer.writeByte((if (harvestToMintEnabled) 1 else 0).toByte())
         buffer.write(withheldAmount.bytes)
         return buffer.readByteArray()
       }
@@ -2753,7 +2682,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(17)
+        buffer.writeShortLe(17.toShort())
         buffer.write(withheldAmount.bytes)
         return buffer.readByteArray()
       }
@@ -2765,7 +2694,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(18)
+        buffer.writeShortLe(18.toShort())
         if (authority != null) {
           buffer.write(authority.bytes)
         } else {
@@ -2790,7 +2719,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(19)
+        buffer.writeShortLe(19.toShort())
         if (updateAuthority != null) {
           buffer.write(updateAuthority.bytes)
         } else {
@@ -2817,7 +2746,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(20)
+        buffer.writeShortLe(20.toShort())
         if (authority != null) {
           buffer.write(authority.bytes)
         } else {
@@ -2840,7 +2769,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(21)
+        buffer.writeShortLe(21.toShort())
         if (updateAuthority != null) {
           buffer.write(updateAuthority.bytes)
         } else {
@@ -2859,7 +2788,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(22)
+        buffer.writeShortLe(22.toShort())
         if (authority != null) {
           buffer.write(authority.bytes)
         } else {
@@ -2881,7 +2810,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(23)
+        buffer.writeShortLe(23.toShort())
         buffer.write(mint.bytes)
         buffer.write(group.bytes)
         buffer.writeLongLe(memberNumber.toLong())
@@ -2892,7 +2821,7 @@ public object Token2022Program : TokenProgram() {
     public object ConfidentialMintBurn : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(24)
+        buffer.writeShortLe(24.toShort())
         return buffer.readByteArray()
       }
     }
@@ -2905,7 +2834,7 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(25)
+        buffer.writeShortLe(25.toShort())
         buffer.write(authority.bytes)
         buffer.writeLongLe(multiplier.toRawBits())
         buffer.writeLongLe(newMultiplierEffectiveTimestamp.toLong())
@@ -2920,13 +2849,13 @@ public object Token2022Program : TokenProgram() {
     ) : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(26)
+        buffer.writeShortLe(26.toShort())
         if (authority != null) {
           buffer.write(authority.bytes)
         } else {
           buffer.write(ByteArray(32))
         }
-        buffer.writeByte(if (paused) 1 else 0)
+        buffer.writeByte((if (paused) 1 else 0).toByte())
         return buffer.readByteArray()
       }
     }
@@ -2934,7 +2863,7 @@ public object Token2022Program : TokenProgram() {
     public object PausableAccount : Extension() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeShortLe(27)
+        buffer.writeShortLe(27.toShort())
         return buffer.readByteArray()
       }
     }
@@ -2993,7 +2922,7 @@ public object Token2022Program : TokenProgram() {
     ) : TokenMetadataField() {
       public override fun serialize(): ByteArray {
         val buffer = Buffer()
-        buffer.writeByte(3)
+        buffer.writeByte(3.toByte())
         val value0Bytes = value0.encodeToByteArray()
         buffer.writeIntLe(value0Bytes.size)
         buffer.write(value0Bytes)

--- a/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/TokenProgram.kt
+++ b/solana-kotlin/src/commonMain/generated/net/avianlabs/solana/domain/program/TokenProgram.kt
@@ -11,11 +11,16 @@ import kotlin.Long
 import kotlin.String
 import kotlin.UByte
 import kotlin.ULong
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.io.writeIntLe
+import kotlinx.io.writeLongLe
+import kotlinx.io.writeShortLe
+import kotlinx.io.writeString
 import net.avianlabs.solana.domain.core.AccountMeta
 import net.avianlabs.solana.domain.core.TransactionInstruction
 import net.avianlabs.solana.domain.program.Program.Companion.createTransactionInstruction
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
-import okio.Buffer
 
 public sealed class TokenProgram : Program {
   public abstract fun initializeMint(
@@ -267,19 +272,17 @@ public sealed class TokenProgram : Program {
         AccountMeta(mint, isSigner = false, isWritable = true),
         AccountMeta(rent, isSigner = false, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.InitializeMint.index.toInt())
-        .writeByte(decimals.toInt())
-        .write(mintAuthority.bytes)
-        .apply {
-          if (freezeAuthority != null) {
-            writeByte(1)
-            .write(freezeAuthority.bytes)
-          } else {
-            writeByte(0)
-          }
+      data = Buffer().apply {
+        writeByte(Instruction.InitializeMint.index.toByte())
+        writeByte(decimals.toByte())
+        write(mintAuthority.bytes)
+        if (freezeAuthority != null) {
+          writeByte(1.toByte())
+          write(freezeAuthority.bytes)
+        } else {
+          writeByte(0.toByte())
         }
-        .readByteArray(),
+      }.readByteArray(),
     )
 
     /**
@@ -316,9 +319,9 @@ public sealed class TokenProgram : Program {
         AccountMeta(owner, isSigner = false, isWritable = false),
         AccountMeta(rent, isSigner = false, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.InitializeAccount.index.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.InitializeAccount.index.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -352,10 +355,10 @@ public sealed class TokenProgram : Program {
         AccountMeta(multisig, isSigner = false, isWritable = true),
         AccountMeta(rent, isSigner = false, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.InitializeMultisig.index.toInt())
-        .writeByte(m.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.InitializeMultisig.index.toByte())
+        writeByte(m.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -384,10 +387,10 @@ public sealed class TokenProgram : Program {
         AccountMeta(destination, isSigner = false, isWritable = true),
         AccountMeta(authority, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.Transfer.index.toInt())
-        .writeLongLe(amount.toLong())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.Transfer.index.toByte())
+        writeLongLe(amount.toLong())
+      }.readByteArray(),
     )
 
     /**
@@ -415,10 +418,10 @@ public sealed class TokenProgram : Program {
         AccountMeta(delegate, isSigner = false, isWritable = false),
         AccountMeta(owner, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.Approve.index.toInt())
-        .writeLongLe(amount.toLong())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.Approve.index.toByte())
+        writeLongLe(amount.toLong())
+      }.readByteArray(),
     )
 
     /**
@@ -437,9 +440,9 @@ public sealed class TokenProgram : Program {
         AccountMeta(source, isSigner = false, isWritable = true),
         AccountMeta(owner, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.Revoke.index.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.Revoke.index.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -465,18 +468,16 @@ public sealed class TokenProgram : Program {
         AccountMeta(owned, isSigner = false, isWritable = true),
         AccountMeta(owner, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.SetAuthority.index.toInt())
-        .writeByte(authorityType.value.toInt())
-        .apply {
-          if (newAuthority != null) {
-            writeByte(1)
-            .write(newAuthority.bytes)
-          } else {
-            writeByte(0)
-          }
+      data = Buffer().apply {
+        writeByte(Instruction.SetAuthority.index.toByte())
+        writeByte(authorityType.value.toByte())
+        if (newAuthority != null) {
+          writeByte(1.toByte())
+          write(newAuthority.bytes)
+        } else {
+          writeByte(0.toByte())
         }
-        .readByteArray(),
+      }.readByteArray(),
     )
 
     /**
@@ -503,10 +504,10 @@ public sealed class TokenProgram : Program {
         AccountMeta(token, isSigner = false, isWritable = true),
         AccountMeta(mintAuthority, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.MintTo.index.toInt())
-        .writeLongLe(amount.toLong())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.MintTo.index.toByte())
+        writeLongLe(amount.toLong())
+      }.readByteArray(),
     )
 
     /**
@@ -534,10 +535,10 @@ public sealed class TokenProgram : Program {
         AccountMeta(mint, isSigner = false, isWritable = true),
         AccountMeta(authority, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.Burn.index.toInt())
-        .writeLongLe(amount.toLong())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.Burn.index.toByte())
+        writeLongLe(amount.toLong())
+      }.readByteArray(),
     )
 
     /**
@@ -563,9 +564,9 @@ public sealed class TokenProgram : Program {
         AccountMeta(destination, isSigner = false, isWritable = true),
         AccountMeta(owner, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.CloseAccount.index.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.CloseAccount.index.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -590,9 +591,9 @@ public sealed class TokenProgram : Program {
         AccountMeta(mint, isSigner = false, isWritable = false),
         AccountMeta(owner, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.FreezeAccount.index.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.FreezeAccount.index.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -617,9 +618,9 @@ public sealed class TokenProgram : Program {
         AccountMeta(mint, isSigner = false, isWritable = false),
         AccountMeta(owner, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.ThawAccount.index.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.ThawAccount.index.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -658,11 +659,11 @@ public sealed class TokenProgram : Program {
         AccountMeta(destination, isSigner = false, isWritable = true),
         AccountMeta(authority, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.TransferChecked.index.toInt())
-        .writeLongLe(amount.toLong())
-        .writeByte(decimals.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.TransferChecked.index.toByte())
+        writeLongLe(amount.toLong())
+        writeByte(decimals.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -700,11 +701,11 @@ public sealed class TokenProgram : Program {
         AccountMeta(delegate, isSigner = false, isWritable = false),
         AccountMeta(owner, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.ApproveChecked.index.toInt())
-        .writeLongLe(amount.toLong())
-        .writeByte(decimals.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.ApproveChecked.index.toByte())
+        writeLongLe(amount.toLong())
+        writeByte(decimals.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -737,11 +738,11 @@ public sealed class TokenProgram : Program {
         AccountMeta(token, isSigner = false, isWritable = true),
         AccountMeta(mintAuthority, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.MintToChecked.index.toInt())
-        .writeLongLe(amount.toLong())
-        .writeByte(decimals.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.MintToChecked.index.toByte())
+        writeLongLe(amount.toLong())
+        writeByte(decimals.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -775,11 +776,11 @@ public sealed class TokenProgram : Program {
         AccountMeta(mint, isSigner = false, isWritable = true),
         AccountMeta(authority, isSigner = true, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.BurnChecked.index.toInt())
-        .writeLongLe(amount.toLong())
-        .writeByte(decimals.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.BurnChecked.index.toByte())
+        writeLongLe(amount.toLong())
+        writeByte(decimals.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -809,10 +810,10 @@ public sealed class TokenProgram : Program {
         AccountMeta(mint, isSigner = false, isWritable = false),
         AccountMeta(rent, isSigner = false, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.InitializeAccount2.index.toInt())
-        .write(owner.bytes)
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.InitializeAccount2.index.toByte())
+        write(owner.bytes)
+      }.readByteArray(),
     )
 
     /**
@@ -831,9 +832,9 @@ public sealed class TokenProgram : Program {
       keys = listOf(
         AccountMeta(account, isSigner = false, isWritable = true),
       ),
-      data = Buffer()
-        .writeByte(Instruction.SyncNative.index.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.SyncNative.index.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -857,10 +858,10 @@ public sealed class TokenProgram : Program {
         AccountMeta(account, isSigner = false, isWritable = true),
         AccountMeta(mint, isSigner = false, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.InitializeAccount3.index.toInt())
-        .write(owner.bytes)
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.InitializeAccount3.index.toByte())
+        write(owner.bytes)
+      }.readByteArray(),
     )
 
     /**
@@ -878,10 +879,10 @@ public sealed class TokenProgram : Program {
       keys = listOf(
         AccountMeta(multisig, isSigner = false, isWritable = true),
       ),
-      data = Buffer()
-        .writeByte(Instruction.InitializeMultisig2.index.toInt())
-        .writeByte(m.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.InitializeMultisig2.index.toByte())
+        writeByte(m.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -906,19 +907,17 @@ public sealed class TokenProgram : Program {
       keys = listOf(
         AccountMeta(mint, isSigner = false, isWritable = true),
       ),
-      data = Buffer()
-        .writeByte(Instruction.InitializeMint2.index.toInt())
-        .writeByte(decimals.toInt())
-        .write(mintAuthority.bytes)
-        .apply {
-          if (freezeAuthority != null) {
-            writeByte(1)
-            .write(freezeAuthority.bytes)
-          } else {
-            writeByte(0)
-          }
+      data = Buffer().apply {
+        writeByte(Instruction.InitializeMint2.index.toByte())
+        writeByte(decimals.toByte())
+        write(mintAuthority.bytes)
+        if (freezeAuthority != null) {
+          writeByte(1.toByte())
+          write(freezeAuthority.bytes)
+        } else {
+          writeByte(0.toByte())
         }
-        .readByteArray(),
+      }.readByteArray(),
     )
 
     /**
@@ -937,9 +936,9 @@ public sealed class TokenProgram : Program {
       keys = listOf(
         AccountMeta(mint, isSigner = false, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.GetAccountDataSize.index.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.GetAccountDataSize.index.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -960,9 +959,9 @@ public sealed class TokenProgram : Program {
       keys = listOf(
         AccountMeta(account, isSigner = false, isWritable = true),
       ),
-      data = Buffer()
-        .writeByte(Instruction.InitializeImmutableOwner.index.toInt())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.InitializeImmutableOwner.index.toByte())
+      }.readByteArray(),
     )
 
     /**
@@ -987,10 +986,10 @@ public sealed class TokenProgram : Program {
       keys = listOf(
         AccountMeta(mint, isSigner = false, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.AmountToUiAmount.index.toInt())
-        .writeLongLe(amount.toLong())
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.AmountToUiAmount.index.toByte())
+        writeLongLe(amount.toLong())
+      }.readByteArray(),
     )
 
     /**
@@ -1013,10 +1012,10 @@ public sealed class TokenProgram : Program {
       keys = listOf(
         AccountMeta(mint, isSigner = false, isWritable = false),
       ),
-      data = Buffer()
-        .writeByte(Instruction.UiAmountToAmount.index.toInt())
-        .writeUtf8(uiAmount)
-        .readByteArray(),
+      data = Buffer().apply {
+        writeByte(Instruction.UiAmountToAmount.index.toByte())
+        writeString(uiAmount)
+      }.readByteArray(),
     )
   }
 }

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/DecodedTransaction.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/DecodedTransaction.kt
@@ -4,10 +4,12 @@ import net.avianlabs.solana.domain.program.AssociatedTokenProgram
 import net.avianlabs.solana.domain.program.SystemProgram
 import net.avianlabs.solana.domain.program.TokenProgram
 import net.avianlabs.solana.methods.TransactionResponse
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.io.readLongLe
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
 import net.avianlabs.solana.tweetnacl.vendor.decodeBase58
 import net.avianlabs.solana.tweetnacl.vendor.encodeToBase58String
-import okio.Buffer
 
 public data class DecodedTransaction(
   val instructions: List<DecodedInstruction>,
@@ -202,7 +204,7 @@ public fun TransactionResponse.decode(): DecodedTransaction? {
       )
     }
     val data = instruction.data!!.decodeBase58()
-    val buffer = Buffer().write(data)
+    val buffer = Buffer().apply { write(data) }
     val raw = DecodedInstruction.Raw(
       program = programKey,
       accounts = accountsMeta,
@@ -233,8 +235,7 @@ public fun TransactionResponse.decode(): DecodedTransaction? {
           SystemProgram.Instruction.AuthorizeNonceAccount.index -> {
             val nonceAccount = accountsMeta!![0]
             val authorizedPubkey = accountsMeta[1]
-            val newAuthorizedBytes = ByteArray(32)
-            buffer.read(newAuthorizedBytes)
+            val newAuthorizedBytes = buffer.readByteArray(32)
             DecodedInstruction.SystemProgram.AuthorizeNonceAccount(
               nonceAccount = nonceAccount.publicKey,
               authorizedPubkey = authorizedPubkey.publicKey,
@@ -246,8 +247,7 @@ public fun TransactionResponse.decode(): DecodedTransaction? {
             val (from, newAccount) = accountsMeta!!
             val lamports = buffer.readLongLe()
             val space = buffer.readLongLe()
-            val ownerBytes = ByteArray(32)
-            buffer.read(ownerBytes)
+            val ownerBytes = buffer.readByteArray(32)
             DecodedInstruction.SystemProgram.CreateAccount(
               from = from.publicKey,
               newAccount = newAccount.publicKey,
@@ -259,8 +259,7 @@ public fun TransactionResponse.decode(): DecodedTransaction? {
 
           SystemProgram.Instruction.InitializeNonceAccount.index -> {
             val nonceAccount = accountsMeta!![0]
-            val authorizedBytes = ByteArray(32)
-            buffer.read(authorizedBytes)
+            val authorizedBytes = buffer.readByteArray(32)
             DecodedInstruction.SystemProgram.InitializeNonceAccount(
               nonceAccount = nonceAccount.publicKey,
               authorizedPubkey = PublicKey(authorizedBytes),

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/DeserializeVersionedMessage.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/DeserializeVersionedMessage.kt
@@ -1,10 +1,11 @@
 package net.avianlabs.solana.domain.core
 
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import net.avianlabs.solana.tweetnacl.TweetNaCl
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
 import net.avianlabs.solana.tweetnacl.vendor.encodeToBase58String
 import net.avianlabs.solana.vendor.ShortVecEncoding
-import okio.Buffer
 
 /**
  * Deserializes a [VersionedMessage] from its binary wire format.
@@ -65,7 +66,7 @@ private fun deserializeV0(source: Buffer): VersionedMessage.V0 {
 }
 
 private fun readHeader(source: Buffer): Header {
-  val headerBytes = source.readByteArray(Header.HEADER_LENGTH.toLong())
+  val headerBytes = source.readByteArray(Header.HEADER_LENGTH)
   return Header.fromByteArray(headerBytes)
 }
 
@@ -76,7 +77,7 @@ private fun readAccountKeys(source: Buffer, header: Header): List<AccountMeta> {
   val numReadonlyUnsignedAccounts = header.numReadonlyUnsignedAccounts.toInt() and 0xFF
 
   return List(numAccounts) { index ->
-    val key = PublicKey(source.readByteArray(TweetNaCl.Signature.PUBLIC_KEY_BYTES.toLong()))
+    val key = PublicKey(source.readByteArray(TweetNaCl.Signature.PUBLIC_KEY_BYTES))
     val isSigner = index < numRequiredSignatures
     val isWritable = if (isSigner) {
       index < numRequiredSignatures - numReadonlySignedAccounts
@@ -88,7 +89,7 @@ private fun readAccountKeys(source: Buffer, header: Header): List<AccountMeta> {
 }
 
 private fun readBlockHash(source: Buffer): String =
-  source.readByteArray(RECENT_BLOCK_HASH_LENGTH.toLong()).encodeToBase58String()
+  source.readByteArray(RECENT_BLOCK_HASH_LENGTH).encodeToBase58String()
 
 private fun readInstructions(
   source: Buffer,
@@ -98,9 +99,9 @@ private fun readInstructions(
   return List(numInstructions) {
     val programIdIndex = source.readByte().toInt() and 0xFF
     val numKeyIndices = ShortVecEncoding.decodeLength(source)
-    val keyIndices = source.readByteArray(numKeyIndices.toLong())
+    val keyIndices = source.readByteArray(numKeyIndices)
     val dataLength = ShortVecEncoding.decodeLength(source)
-    val data = source.readByteArray(dataLength.toLong())
+    val data = source.readByteArray(dataLength)
 
     val programId = accountKeys.getOrPlaceholder(programIdIndex).publicKey
     val keys = keyIndices.map { index ->
@@ -118,7 +119,7 @@ private fun readInstructions(
 private fun readAddressTableLookups(source: Buffer): List<MessageAddressTableLookup> {
   val numLookups = ShortVecEncoding.decodeLength(source)
   return List(numLookups) {
-    val accountKey = PublicKey(source.readByteArray(TweetNaCl.Signature.PUBLIC_KEY_BYTES.toLong()))
+    val accountKey = PublicKey(source.readByteArray(TweetNaCl.Signature.PUBLIC_KEY_BYTES))
     val numWritable = ShortVecEncoding.decodeLength(source)
     val writableIndexes = List(numWritable) { source.readByte().toUByte() }
     val numReadonly = ShortVecEncoding.decodeLength(source)

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/FeeCalculator.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/FeeCalculator.kt
@@ -1,14 +1,15 @@
 package net.avianlabs.solana.domain.core
 
+import kotlinx.io.Source
+import kotlinx.io.readLongLe
 import kotlinx.serialization.Serializable
-import okio.BufferedSource
 
 @Serializable
 public data class FeeCalculator(
   val lamportsPerSignature: ULong,
 ) {
   public companion object {
-    public fun read(data: BufferedSource): FeeCalculator = FeeCalculator(
+    internal fun read(data: Source): FeeCalculator = FeeCalculator(
       lamportsPerSignature = data.readLongLe().toULong(),
     )
   }

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/NonceAccountData.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/NonceAccountData.kt
@@ -1,7 +1,8 @@
 package net.avianlabs.solana.domain.core
 
+import kotlinx.io.Source
+import kotlinx.io.readIntLe
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
-import okio.BufferedSource
 
 public data class NonceAccountData(
   val version: UInt,
@@ -11,7 +12,7 @@ public data class NonceAccountData(
   val feeCalculator: FeeCalculator,
 ) {
   public companion object {
-    public fun read(data: BufferedSource): NonceAccountData {
+    internal fun read(data: Source): NonceAccountData {
       val version = data.readIntLe().toUInt()
       val state = data.readIntLe().toUInt()
       val authorizedPubkey = PublicKey.read(data)

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/PublicKey.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/PublicKey.kt
@@ -1,8 +1,9 @@
 package net.avianlabs.solana.domain.core
 
+import kotlinx.io.Source
+import kotlinx.io.readByteArray
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
-import okio.BufferedSource
 
-public fun PublicKey.Companion.read(data: BufferedSource): PublicKey = PublicKey(
+internal fun PublicKey.Companion.read(data: Source): PublicKey = PublicKey(
   bytes = data.readByteArray(32),
 )

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/SerializeMessage.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/SerializeMessage.kt
@@ -1,11 +1,12 @@
 package net.avianlabs.solana.domain.core
 
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import net.avianlabs.solana.tweetnacl.TweetNaCl
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
 import net.avianlabs.solana.tweetnacl.vendor.decodeBase58
 import net.avianlabs.solana.vendor.ShortVecEncoding
 import net.avianlabs.solana.vendor.ShortVecLength
-import okio.Buffer
 
 internal const val RECENT_BLOCK_HASH_LENGTH = 32
 
@@ -108,12 +109,12 @@ public fun Message.serialize(): ByteArray {
     write(recentBlockHash.decodeBase58())
     write(instructionsLength)
     for (compiledInstruction in compiledInstructions) {
-      writeByte(compiledInstruction.programIdIndex.toInt())
+      writeByte(compiledInstruction.programIdIndex)
       write(compiledInstruction.keyIndicesLength)
       write(compiledInstruction.keyIndices)
       write(compiledInstruction.dataLength)
       write(compiledInstruction.data)
     }
   }
-  return buffer.readByteArray(bufferSize.toLong())
+  return buffer.readByteArray(bufferSize)
 }

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/SerializeVersionedMessage.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/SerializeVersionedMessage.kt
@@ -1,10 +1,11 @@
 package net.avianlabs.solana.domain.core
 
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import net.avianlabs.solana.tweetnacl.TweetNaCl
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
 import net.avianlabs.solana.tweetnacl.vendor.decodeBase58
 import net.avianlabs.solana.vendor.ShortVecEncoding
-import okio.Buffer
 
 /**
  * Serializes a [VersionedMessage] to its binary wire format.
@@ -52,7 +53,7 @@ private fun VersionedMessage.V0.serializeV0(): ByteArray {
 
   val buffer = Buffer().apply {
     // V0 version prefix
-    writeByte(0x80)
+    writeByte(0x80.toByte())
     // Header (3 bytes)
     write(messageHeader.toByteArray())
     // Static account keys
@@ -63,7 +64,7 @@ private fun VersionedMessage.V0.serializeV0(): ByteArray {
     // Instructions
     write(instructionsLength)
     for (compiledInstruction in compiledInstructions) {
-      writeByte(compiledInstruction.programIdIndex.toInt())
+      writeByte(compiledInstruction.programIdIndex)
       write(compiledInstruction.keyIndicesLength)
       write(compiledInstruction.keyIndices)
       write(compiledInstruction.dataLength)
@@ -75,11 +76,11 @@ private fun VersionedMessage.V0.serializeV0(): ByteArray {
       write(lookup.accountKey.toByteArray())
       write(ShortVecEncoding.encodeLength(lookup.writableIndexes.size))
       for (index in lookup.writableIndexes) {
-        writeByte(index.toInt())
+        writeByte(index.toByte())
       }
       write(ShortVecEncoding.encodeLength(lookup.readonlyIndexes.size))
       for (index in lookup.readonlyIndexes) {
-        writeByte(index.toInt())
+        writeByte(index.toByte())
       }
     }
   }

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/SerializedTransaction.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/SerializedTransaction.kt
@@ -3,9 +3,10 @@
 package net.avianlabs.solana.domain.core
 
 import io.ktor.util.*
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import net.avianlabs.solana.tweetnacl.TweetNaCl
 import net.avianlabs.solana.vendor.ShortVecEncoding
-import okio.Buffer
 import kotlin.jvm.JvmInline
 
 @JvmInline
@@ -36,7 +37,7 @@ public value class SerializedTransaction(private val bytes: ByteArray) {
 
     val numSignatures = ShortVecEncoding.decodeLength(source)
     val existingSignatures = Array(numSignatures) {
-      source.readByteArray(TweetNaCl.Signature.SIGNATURE_BYTES.toLong())
+      source.readByteArray(TweetNaCl.Signature.SIGNATURE_BYTES)
     }
     val messageBytes = source.readByteArray()
 

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/SignedTransaction.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/SignedTransaction.kt
@@ -3,9 +3,10 @@ package net.avianlabs.solana.domain.core
 import co.touchlab.skie.configuration.annotations.SkieVisibility
 import net.avianlabs.solana.tweetnacl.TweetNaCl
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import net.avianlabs.solana.tweetnacl.vendor.encodeToBase58String
 import net.avianlabs.solana.vendor.ShortVecEncoding
-import okio.Buffer
 
 @Deprecated(
   message = "Use VersionedTransaction instead",
@@ -87,6 +88,6 @@ public data class SignedTransaction(
     out.write(signaturesLength)
     orderedSigs.forEach(out::write)
     out.write(serializedMessage)
-    return SerializedTransaction(out.readByteArray(bufferSize.toLong()))
+    return SerializedTransaction(out.readByteArray(bufferSize))
   }
 }

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/VersionedTransaction.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/core/VersionedTransaction.kt
@@ -1,10 +1,11 @@
 package net.avianlabs.solana.domain.core
 
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import net.avianlabs.solana.tweetnacl.TweetNaCl
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
 import net.avianlabs.solana.tweetnacl.vendor.encodeToBase58String
 import net.avianlabs.solana.vendor.ShortVecEncoding
-import okio.Buffer
 
 /**
  * A transaction that supports both legacy and V0 (versioned) message formats.
@@ -107,7 +108,7 @@ public class VersionedTransaction internal constructor(
     out.write(signaturesLength)
     orderedSigs.forEach(out::write)
     out.write(msgBytes)
-    return SerializedTransaction(out.readByteArray(bufferSize.toLong()))
+    return SerializedTransaction(out.readByteArray(bufferSize))
   }
 
   private fun rebuildWithFeePayer(feePayer: PublicKey): VersionedMessage =
@@ -161,7 +162,7 @@ public class VersionedTransaction internal constructor(
 
       val numSignatures = ShortVecEncoding.decodeLength(source)
       val existingSignatures = Array(numSignatures) {
-        source.readByteArray(TweetNaCl.Signature.SIGNATURE_BYTES.toLong())
+        source.readByteArray(TweetNaCl.Signature.SIGNATURE_BYTES)
       }
       val messageBytes = source.readByteArray()
 

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/program/Program.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/domain/program/Program.kt
@@ -1,10 +1,11 @@
 package net.avianlabs.solana.domain.program
 
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import net.avianlabs.solana.domain.core.AccountMeta
 import net.avianlabs.solana.domain.core.TransactionInstruction
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
 import net.avianlabs.solana.tweetnacl.vendor.Sha256
-import okio.Buffer
 
 public interface Program {
 
@@ -46,15 +47,11 @@ public interface Program {
         }
       }
 
-      val bytes = Buffer()
-        .apply {
-          seeds.forEach { seed ->
-            write(seed)
-          }
-        }
-        .write(programId.bytes)
-        .write("ProgramDerivedAddress".encodeToByteArray())
-        .readByteArray()
+      val bytes = Buffer().apply {
+        seeds.forEach { seed -> write(seed) }
+        write(programId.bytes)
+        write("ProgramDerivedAddress".encodeToByteArray())
+      }.readByteArray()
 
       val hash = Sha256.digest(bytes)
 

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/methods/getNonce.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/methods/getNonce.kt
@@ -5,7 +5,7 @@ import net.avianlabs.solana.domain.core.Commitment
 import net.avianlabs.solana.domain.core.FeeCalculator
 import net.avianlabs.solana.domain.core.NonceAccountData
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
-import okio.Buffer
+import kotlinx.io.Buffer
 
 public suspend fun SolanaClient.getNonce(
   publicKey: PublicKey,
@@ -15,7 +15,7 @@ public suspend fun SolanaClient.getNonce(
   ?.value
   ?.dataBytes
   ?.let { data ->
-    val decoded = NonceAccountData.read(Buffer().write(data))
+    val decoded = NonceAccountData.read(Buffer().apply { write(data) })
     NonceAccount(
       authorizedPubkey = decoded.authorizedPubkey,
       nonce = decoded.nonce,

--- a/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/vendor/ShortVecEncoding.kt
+++ b/solana-kotlin/src/commonMain/kotlin/net/avianlabs/solana/vendor/ShortVecEncoding.kt
@@ -1,7 +1,8 @@
 package net.avianlabs.solana.vendor
 
-import okio.Buffer
-import okio.BufferedSource
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+import kotlinx.io.readByteArray
 import kotlin.experimental.and
 
 internal typealias ShortVecLength = ByteArray
@@ -14,10 +15,10 @@ internal object ShortVecEncoding {
       val elem = length and 0x7f
       length = length ushr 7
       if (length == 0) {
-        buffer.writeByte(elem)
+        buffer.writeByte(elem.toByte())
         break
       } else {
-        buffer.writeByte(elem or 0x80)
+        buffer.writeByte((elem or 0x80).toByte())
       }
     }
     return buffer.readByteArray()
@@ -37,7 +38,7 @@ internal object ShortVecEncoding {
     return len
   }
 
-  internal fun decodeLength(source: BufferedSource): Int {
+  internal fun decodeLength(source: Source): Int {
     var len = 0
     var shift = 0
     while (true) {

--- a/solana-kotlin/src/commonTest/kotlin/net/avianlabs/solana/domain/core/DeserializeVersionedMessageTest.kt
+++ b/solana-kotlin/src/commonTest/kotlin/net/avianlabs/solana/domain/core/DeserializeVersionedMessageTest.kt
@@ -4,7 +4,8 @@ import net.avianlabs.solana.domain.program.SystemProgram
 import net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
 import net.avianlabs.solana.vendor.ShortVecEncoding
-import okio.Buffer
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -38,10 +39,10 @@ class DeserializeVersionedMessageTest {
     val recipientKey = PublicKey(ByteArray(32) { 0x42 })
 
     val messageBuffer = Buffer().apply {
-      writeByte(0x80) // V0 prefix
-      writeByte(1)    // numRequiredSignatures
-      writeByte(0)    // numReadonlySignedAccounts
-      writeByte(1)    // numReadonlyUnsignedAccounts (program)
+      writeByte(0x80.toByte()) // V0 prefix
+      writeByte(1.toByte())    // numRequiredSignatures
+      writeByte(0.toByte())    // numReadonlySignedAccounts
+      writeByte(1.toByte())    // numReadonlyUnsignedAccounts (program)
       write(ShortVecEncoding.encodeLength(3))
       write(keypair.publicKey.toByteArray())
       write(recipientKey.toByteArray())
@@ -49,10 +50,10 @@ class DeserializeVersionedMessageTest {
       write(ByteArray(32) { 0xAA.toByte() }) // blockhash
       // 1 instruction referencing static keys only
       write(ShortVecEncoding.encodeLength(1))
-      writeByte(2) // programIdIndex
+      writeByte(2.toByte()) // programIdIndex
       write(ShortVecEncoding.encodeLength(2))
-      writeByte(0) // account index 0
-      writeByte(1) // account index 1
+      writeByte(0.toByte()) // account index 0
+      writeByte(1.toByte()) // account index 1
       write(ShortVecEncoding.encodeLength(0)) // no data
       // 0 ALT lookups
       write(ShortVecEncoding.encodeLength(0))
@@ -124,10 +125,10 @@ class DeserializeVersionedMessageTest {
     val recipientKey = PublicKey(ByteArray(32) { 0x42 })
 
     val messageBuffer = Buffer().apply {
-      writeByte(0x80) // V0 prefix
-      writeByte(1)    // numRequiredSignatures
-      writeByte(0)    // numReadonlySignedAccounts
-      writeByte(1)    // numReadonlyUnsignedAccounts (program)
+      writeByte(0x80.toByte()) // V0 prefix
+      writeByte(1.toByte())    // numRequiredSignatures
+      writeByte(0.toByte())    // numReadonlySignedAccounts
+      writeByte(1.toByte())    // numReadonlyUnsignedAccounts (program)
       write(ShortVecEncoding.encodeLength(3))
       write(keypair.publicKey.toByteArray())
       write(recipientKey.toByteArray())
@@ -135,19 +136,19 @@ class DeserializeVersionedMessageTest {
       write(ByteArray(32) { 0xAA.toByte() }) // blockhash
       // 1 instruction
       write(ShortVecEncoding.encodeLength(1))
-      writeByte(2)
+      writeByte(2.toByte())
       write(ShortVecEncoding.encodeLength(2))
-      writeByte(0)
-      writeByte(1)
+      writeByte(0.toByte())
+      writeByte(1.toByte())
       write(ShortVecEncoding.encodeLength(0))
       // 1 ALT lookup
       write(ShortVecEncoding.encodeLength(1))
       write(altKey.toByteArray())
       write(ShortVecEncoding.encodeLength(2))
-      writeByte(3)
-      writeByte(5)
+      writeByte(3.toByte())
+      writeByte(5.toByte())
       write(ShortVecEncoding.encodeLength(1))
-      writeByte(7)
+      writeByte(7.toByte())
     }
     val bytes = messageBuffer.readByteArray()
 
@@ -164,10 +165,10 @@ class DeserializeVersionedMessageTest {
   @Test
   fun unsupportedVersion_throws() {
     val messageBuffer = Buffer().apply {
-      writeByte(0x81) // version 1
-      writeByte(1)
-      writeByte(0)
-      writeByte(0)
+      writeByte(0x81.toByte()) // version 1
+      writeByte(1.toByte())
+      writeByte(0.toByte())
+      writeByte(0.toByte())
       write(ShortVecEncoding.encodeLength(1))
       write(keypair.publicKey.toByteArray())
       write(ByteArray(32))

--- a/solana-kotlin/src/commonTest/kotlin/net/avianlabs/solana/domain/core/SerializedTransactionV0Test.kt
+++ b/solana-kotlin/src/commonTest/kotlin/net/avianlabs/solana/domain/core/SerializedTransactionV0Test.kt
@@ -4,7 +4,8 @@ import net.avianlabs.solana.tweetnacl.TweetNaCl
 import net.avianlabs.solana.tweetnacl.ed25519.Ed25519Keypair
 import net.avianlabs.solana.tweetnacl.ed25519.PublicKey
 import net.avianlabs.solana.vendor.ShortVecEncoding
-import okio.Buffer
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertTrue
@@ -36,11 +37,11 @@ class SerializedTransactionV0Test {
     // Build V0 message bytes
     val messageBuffer = Buffer().apply {
       // Version prefix (V0)
-      writeByte(0x80)
+      writeByte(0x80.toByte())
       // Header: 1 required signature, 0 readonly signed, 1 readonly unsigned (program)
-      writeByte(numSignatures) // numRequiredSignatures
-      writeByte(0)             // numReadonlySignedAccounts
-      writeByte(1)             // numReadonlyUnsignedAccounts
+      writeByte(numSignatures.toByte()) // numRequiredSignatures
+      writeByte(0.toByte())             // numReadonlySignedAccounts
+      writeByte(1.toByte())             // numReadonlyUnsignedAccounts
       // Account count: signer + recipient + program = 3
       write(ShortVecEncoding.encodeLength(3))
       // Account keys (order: signer first, then writable, then readonly)
@@ -52,10 +53,10 @@ class SerializedTransactionV0Test {
       // Instructions: 1 instruction
       write(ShortVecEncoding.encodeLength(1))
       // Instruction: programIdIndex=2, 2 account indices [0, 1], no data
-      writeByte(2)
+      writeByte(2.toByte())
       write(ShortVecEncoding.encodeLength(2))
-      writeByte(0)
-      writeByte(1)
+      writeByte(0.toByte())
+      writeByte(1.toByte())
       write(ShortVecEncoding.encodeLength(0))
       // Address table lookups: none
       write(ShortVecEncoding.encodeLength(0))
@@ -155,10 +156,10 @@ class SerializedTransactionV0Test {
   fun toVersionedTransaction_unsupportedVersion_throws() {
     // Build a transaction with version 1 prefix (0x81)
     val messageBuffer = Buffer().apply {
-      writeByte(0x81) // version 1
-      writeByte(1)
-      writeByte(0)
-      writeByte(0)
+      writeByte(0x81.toByte()) // version 1
+      writeByte(1.toByte())
+      writeByte(0.toByte())
+      writeByte(0.toByte())
       write(ShortVecEncoding.encodeLength(1))
       write(keypair.publicKey.toByteArray())
       write(ByteArray(32))
@@ -188,10 +189,10 @@ class SerializedTransactionV0Test {
     val blockhash = ByteArray(32) { 0xAA.toByte() }
 
     val messageBuffer = Buffer().apply {
-      writeByte(0x80) // V0 prefix
-      writeByte(1)    // numRequiredSignatures
-      writeByte(0)    // numReadonlySignedAccounts
-      writeByte(1)    // numReadonlyUnsignedAccounts
+      writeByte(0x80.toByte()) // V0 prefix
+      writeByte(1.toByte())    // numRequiredSignatures
+      writeByte(0.toByte())    // numReadonlySignedAccounts
+      writeByte(1.toByte())    // numReadonlyUnsignedAccounts
       // 3 static account keys
       write(ShortVecEncoding.encodeLength(3))
       write(keypair.publicKey.toByteArray())
@@ -200,17 +201,17 @@ class SerializedTransactionV0Test {
       write(blockhash)
       // 1 instruction
       write(ShortVecEncoding.encodeLength(1))
-      writeByte(2)
+      writeByte(2.toByte())
       write(ShortVecEncoding.encodeLength(2))
-      writeByte(0)
-      writeByte(1)
+      writeByte(0.toByte())
+      writeByte(1.toByte())
       write(ShortVecEncoding.encodeLength(0))
       // 1 address table lookup
       write(ShortVecEncoding.encodeLength(1))
       write(altKey.toByteArray())
       // 1 writable index
       write(ShortVecEncoding.encodeLength(1))
-      writeByte(3)
+      writeByte(3.toByte())
       // 0 readonly indices
       write(ShortVecEncoding.encodeLength(0))
     }

--- a/solana-kotlin/src/commonTest/kotlin/net/avianlabs/solana/vendor/ShortvecEncodingTest.kt
+++ b/solana-kotlin/src/commonTest/kotlin/net/avianlabs/solana/vendor/ShortvecEncodingTest.kt
@@ -1,6 +1,7 @@
 package net.avianlabs.solana.vendor
 
-import okio.Buffer
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals


### PR DESCRIPTION
okio.Buffer/BufferedSource are replaced with kotlinx.io.Buffer/Source
across the 14 commonMain files that used them, plus the codegen
templates that emit binary serialisation code.

Public API surface stays free of kotlinx-io types. Three previously-
public deserialisation helpers (FeeCalculator.read, NonceAccountData.read,
PublicKey.Companion.read) accepted okio.BufferedSource, so they were
hidden as `internal` rather than re-exposed under a kotlinx.io.Source
parameter. They were already used only inside this module.

Codegen template changes (codegen/.../ProgramGenerator.kt):
- Buffer().chain().chain().readByteArray() pattern rewritten to
  Buffer().apply { ... }.readByteArray() because kotlinx-io's write
  methods return Unit
- writeByte(Int) -> writeByte(Byte): every emitted call now wraps with
  .toByte() / .toShort() as needed
- writeUtf8 -> writeString
- New imports: kotlinx.io.{Buffer, readByteArray, writeIntLe, writeLongLe,
  writeShortLe, writeString}
- sizePrefixTypeNode for strings now uses ${paramName}Bytes to avoid
  variable name collisions when an instruction has multiple string fields

Generated files in solana-kotlin/src/commonMain/generated/ regenerated
to match.

okio is removed from libs.versions.toml; kotlinx-io 0.9.0 takes its
place. BCV baseline updated for the now-internal read helpers.