### PR TITLE
Drop multiplatform-swiftpackage in favour of a custom Gradle task

### DIFF
--- a/.github/workflows/release_swiftpackage.yaml
+++ b/.github/workflows/release_swiftpackage.yaml
@@ -49,7 +49,7 @@ jobs:
           restore-keys: ${{ runner.os }}-konan-
 
       - name: Create Swift package
-        run: ./gradlew -Psnapshot=false :solana-kotlin:createSwiftPackage
+        run: ./gradlew -Psnapshot=false :solana-kotlin:packageSwiftDistribution
 
       - name: Upload artifact to release
         uses: softprops/action-gh-release@v2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,5 +75,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 nmcp = { id = "com.gradleup.nmcp", version = "0.0.9" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
-multiplatform-swiftpackage = { id = "io.github.luca992.multiplatform-swiftpackage", version = "2.3.0" }
 skie = { id = "co.touchlab.skie", version.ref = "skie" }

--- a/solana-kotlin/build.gradle.kts
+++ b/solana-kotlin/build.gradle.kts
@@ -1,5 +1,6 @@
 import co.touchlab.skie.configuration.ClassInterop
 import co.touchlab.skie.configuration.DefaultArgumentInterop
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
   alias(libs.plugins.kotlinMultiplatform)
@@ -8,7 +9,6 @@ plugins {
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.dokka)
   signing
-  alias(libs.plugins.multiplatform.swiftpackage)
   alias(libs.plugins.skie)
 }
 
@@ -31,6 +31,7 @@ kotlin {
     withHostTestBuilder { }
   }
 
+  val xcframework = XCFramework("SolanaKotlin")
   listOf(
     iosArm64(),
     iosSimulatorArm64(),
@@ -41,6 +42,7 @@ kotlin {
       baseName = "SolanaKotlin"
       export(project(":tweetnacl-multiplatform"))
       isStatic = true
+      xcframework.add(this)
     }
   }
 
@@ -116,14 +118,45 @@ skie {
   }
 }
 
-multiplatformSwiftPackage {
-  swiftToolsVersion("5.10")
-  targetPlatforms {
-    iOS { v("17") }
+val packageSwiftDistribution by tasks.registering {
+  group = "distribution"
+  description = "Builds SolanaKotlin XCFramework, zips it, and renders Package.swift"
+
+  val xcFrameworkTask = tasks.named("assembleSolanaKotlinReleaseXCFramework")
+  dependsOn(xcFrameworkTask)
+
+  val xcFrameworkParent = layout.buildDirectory.dir("XCFrameworks/release")
+  val outputDir = layout.projectDirectory.dir("swiftpackage")
+  val versionStr = project.version.toString()
+  val template = layout.projectDirectory.file("swiftpackage/Package.swift.template")
+
+  inputs.dir(xcFrameworkParent)
+  inputs.file(template)
+  inputs.property("version", versionStr)
+  outputs.file(outputDir.file("Package.swift"))
+  outputs.file(outputDir.file("SolanaKotlin.zip"))
+
+  doLast {
+    val zipFile = outputDir.file("SolanaKotlin.zip").asFile
+    zipFile.parentFile.mkdirs()
+    zipFile.delete()
+    ant.withGroovyBuilder {
+      "zip"("destfile" to zipFile) {
+        "fileset"("dir" to xcFrameworkParent.get().asFile) {
+          "include"("name" to "SolanaKotlin.xcframework/**")
+        }
+      }
+    }
+    val checksum = providers.exec {
+      commandLine("swift", "package", "compute-checksum", zipFile.absolutePath)
+    }.standardOutput.asText.get().trim()
+    val url =
+      "https://github.com/avianlabs/solana-kotlin/releases/download/$versionStr/SolanaKotlin.zip"
+    val rendered = template.asFile.readText()
+      .replace("\${RELEASE_URL}", url)
+      .replace("\${CHECKSUM}", checksum)
+    outputDir.file("Package.swift").asFile.writeText(rendered)
   }
-  packageName("SolanaKotlin")
-  zipFileName("SolanaKotlin")
-  distributionMode { remote("https://github.com/avianlabs/solana-kotlin/releases/download/$version") }
 }
 
 signing {

--- a/solana-kotlin/swiftpackage/.gitignore
+++ b/solana-kotlin/swiftpackage/.gitignore
@@ -1,4 +1,5 @@
-# Ignore everything in this directory
+# Ignore everything in this directory by default — generated outputs land here
 *
-# Except this file
+# Except this file and the checked-in template that drives the generator
 !.gitignore
+!Package.swift.template

--- a/solana-kotlin/swiftpackage/Package.swift.template
+++ b/solana-kotlin/swiftpackage/Package.swift.template
@@ -1,0 +1,22 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package = Package(
+    name: "SolanaKotlin",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .library(
+            name: "SolanaKotlin",
+            targets: ["SolanaKotlin"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "SolanaKotlin",
+            url: "${RELEASE_URL}",
+            checksum: "${CHECKSUM}"
+        ),
+    ]
+)

--- a/tweetnacl-multiplatform/build.gradle.kts
+++ b/tweetnacl-multiplatform/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.dokka)
   signing
-  alias(libs.plugins.multiplatform.swiftpackage)
   alias(libs.plugins.skie)
 }
 
@@ -98,15 +97,6 @@ cklib {
       )
     )
   }
-}
-
-multiplatformSwiftPackage {
-  swiftToolsVersion("5.10")
-  targetPlatforms {
-    iOS { v("17") }
-  }
-  packageName("TweetNaClMultiplatform")
-  distributionMode { local() }
 }
 
 signing {


### PR DESCRIPTION
The io.github.luca992.multiplatform-swiftpackage 3rd-party plugin
wrapped SKIE's XCFramework output in a Package.swift + .zip. Same job
in ~50 lines of Gradle that we own.

Replaces:
- alias(libs.plugins.multiplatform.swiftpackage) and the multiplatformSwiftPackage
  config block in solana-kotlin and tweetnacl-multiplatform
- the corresponding entry in libs.versions.toml

With:
- XCFramework("SolanaKotlin") declared in the framework block of
  solana-kotlin so KMP produces an assembleSolanaKotlinReleaseXCFramework
  task (SKIE alone doesn't generate one)
- a checked-in solana-kotlin/swiftpackage/Package.swift.template that
  uses ${RELEASE_URL} and ${CHECKSUM} placeholders
- a packageSwiftDistribution Gradle task that zips the XCFramework,
  computes the checksum via 'swift package compute-checksum', and
  renders the template into Package.swift

iOS minimum bumps .v16 -> .v17 to match what the plugin was already
configured to emit.

CI workflow release_swiftpackage.yaml swaps :solana-kotlin:createSwiftPackage
for :solana-kotlin:packageSwiftDistribution. The upload step still
references solana-kotlin/swiftpackage/SolanaKotlin.zip so no other CI
edits are needed.

The per-directory swiftpackage/.gitignore now whitelists
Package.swift.template alongside .gitignore; everything else (Package.swift,
SolanaKotlin.xcframework, SolanaKotlin.zip) is build output.