### PR TITLE
Wire Dokka V2 HTML aggregation + CI smoke step

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -77,6 +77,9 @@ jobs:
       - name: Run tests
         run: ./gradlew check
 
+      - name: Generate Dokka HTML docs
+        run: ./gradlew dokkaGenerate
+
       - name: Build packages
         run: ./gradlew -PsignPublications=false publishToMavenLocal
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   alias(libs.plugins.kotlinMultiplatform).apply(false)
   alias(libs.plugins.androidKotlinMultiplatformLib).apply(false)
   alias(libs.plugins.binaryCompatibilityValidator)
+  alias(libs.plugins.dokka)
   alias(libs.plugins.nmcp)
 }
 
@@ -17,6 +18,19 @@ apiValidation {
   klib {
     enabled = true
   }
+}
+
+dokka {
+  dokkaPublications.html {
+    moduleName.set(rootProject.name)
+    outputDirectory.set(layout.buildDirectory.dir("docs/html"))
+  }
+}
+
+dependencies {
+  dokka(project(":solana-kotlin"))
+  dokka(project(":tweetnacl-multiplatform"))
+  dokka(project(":solana-kotlin-arrow-extensions"))
 }
 
 nmcp {

--- a/solana-kotlin-arrow-extensions/build.gradle.kts
+++ b/solana-kotlin-arrow-extensions/build.gradle.kts
@@ -48,6 +48,13 @@ kotlin {
   }
 }
 
+dokka {
+  dokkaSourceSets.configureEach {
+    documentedVisibilities.set(setOf(org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier.Public))
+    skipEmptyPackages.set(true)
+  }
+}
+
 signing {
   useGpgCmd()
 }

--- a/solana-kotlin/build.gradle.kts
+++ b/solana-kotlin/build.gradle.kts
@@ -103,6 +103,13 @@ kotlin {
   }
 }
 
+dokka {
+  dokkaSourceSets.configureEach {
+    documentedVisibilities.set(setOf(org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier.Public))
+    skipEmptyPackages.set(true)
+  }
+}
+
 skie {
   features {
     group("net.avianlabs.solana") {

--- a/tweetnacl-multiplatform/build.gradle.kts
+++ b/tweetnacl-multiplatform/build.gradle.kts
@@ -81,6 +81,13 @@ kotlin {
   }
 }
 
+dokka {
+  dokkaSourceSets.configureEach {
+    documentedVisibilities.set(setOf(org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier.Public))
+    skipEmptyPackages.set(true)
+  }
+}
+
 cklib {
   config.kotlinVersion = libs.versions.kotlin.get()
   create("tweetnacl") {


### PR DESCRIPTION
The Dokka plugin was already applied per-module and vanniktech 0.36.0
auto-detects it for the publication's javadoc jar. Two pieces missing:

1. Root project: add the Dokka plugin and aggregate the three library
   modules into a single HTML site under build/docs/html. moduleName
   uses rootProject.name (solana-kotlin-sdk).
2. Per-module: configure dokkaSourceSets.configureEach to emit only
   public declarations (matches explicitApi()) and skip empty packages.
   Uses Dokka V2's VisibilityModifier.Public from
   org.jetbrains.dokka.gradle.engine.parameters.

CI: pull_request.yaml gets a 'Generate Dokka HTML docs' step that runs
./gradlew dokkaGenerate so doc generation is exercised on every PR
even though it's not part of `check`.