### PR TITLE
Bump JDK toolchain 17 -> 21 across modules and CI

### DIFF
--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          java-version: '18'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          java-version: '18'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Android SDK

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          java-version: '18'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          java-version: '18'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Android SDK

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          java-version: '18'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/release_swiftpackage.yaml
+++ b/.github/workflows/release_swiftpackage.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          java-version: '18'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/solana-kotlin-arrow-extensions/build.gradle.kts
+++ b/solana-kotlin-arrow-extensions/build.gradle.kts
@@ -14,7 +14,7 @@ version = properties["version"] as String
 kotlin {
   applyDefaultHierarchyTemplate()
   explicitApi()
-  jvmToolchain(17)
+  jvmToolchain(21)
 
   jvm()
 
@@ -23,7 +23,7 @@ kotlin {
     namespace = "net.avianlabs.solana.arrow"
     compileSdk = libs.versions.androidCompileSdk.get().toInt()
     minSdk = libs.versions.androidMinSdk.get().toInt()
-    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     withHostTestBuilder { }
   }
 

--- a/solana-kotlin/build.gradle.kts
+++ b/solana-kotlin/build.gradle.kts
@@ -18,7 +18,7 @@ version = properties["version"] as String
 kotlin {
   applyDefaultHierarchyTemplate()
   explicitApi()
-  jvmToolchain(17)
+  jvmToolchain(21)
 
   jvm()
 
@@ -27,7 +27,7 @@ kotlin {
     namespace = "net.avianlabs.solana"
     compileSdk = libs.versions.androidCompileSdk.get().toInt()
     minSdk = libs.versions.androidMinSdk.get().toInt()
-    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     withHostTestBuilder { }
   }
 

--- a/tweetnacl-multiplatform/build.gradle.kts
+++ b/tweetnacl-multiplatform/build.gradle.kts
@@ -17,7 +17,7 @@ version = properties["version"] as String
 kotlin {
   applyDefaultHierarchyTemplate()
   explicitApi()
-  jvmToolchain(17)
+  jvmToolchain(21)
 
   jvm()
 
@@ -26,7 +26,7 @@ kotlin {
     namespace = "net.avianlabs.solana.tweetnacl"
     compileSdk = libs.versions.androidCompileSdk.get().toInt()
     minSdk = libs.versions.androidMinSdk.get().toInt()
-    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     withHostTestBuilder { }
   }
 


### PR DESCRIPTION
Promotes the build and target JVM from 17 to 21 (current LTS):
- jvmToolchain(17) -> jvmToolchain(21) in all three library modules
- compilerOptions.jvmTarget JVM_17 -> JVM_21 inside each androidLibrary
  block
- GitHub Actions setup-java java-version '18' -> '21' across
  pull_request.yaml, main_branch.yaml, release.yaml, and
  release_swiftpackage.yaml (update_idl.yaml was already on 21)

Note: this also moves the published JVM/Android bytecode target to 21,
so consumers must build with JDK 21+. Acceptable for the 0.5.0 release
since most modern Android/KMP toolchains have already moved.