### PR TITLE
Run PR workflow regardless of base branch

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,8 +4,6 @@ on:
   merge_group:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-    branches:
-      - main
 
 permissions:
   actions: write


### PR DESCRIPTION
Removes the 'branches: [main]' filter from pull_request.yaml so that
stacked PRs (where most PRs target an intermediate branch instead of
main) also exercise CI. Without this, only the bottom of a Graphite
stack ever runs CI; the rest sit unverified until they land on main.