### PR TITLE
Use ORG_BOT_TOKEN for IDL update PRs

### DIFF
--- a/.github/workflows/update_idl.yaml
+++ b/.github/workflows/update_idl.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         id: cpr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ORG_BOT_TOKEN }}
           commit-message: "update Solana program IDLs and generated code"
           title: "Update Solana IDLs"
           body: |


### PR DESCRIPTION
PRs opened by the default GITHUB_TOKEN don't trigger downstream
workflows, so CI never runs on the auto-generated IDL update PRs.
Switch to ORG_BOT_TOKEN (already used by bump_version.yaml) so the
pull_request workflow fires.

https://claude.ai/code/session_012tsi5YSwiAFf1D1oZinfFR